### PR TITLE
Initialize backend skeleton and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Proje Çağrısı Değerlendirme Platformu
+
+This project aims to provide a multi-role web platform for managing academic and R&D project calls. Applicants submit proposals, reviewers evaluate them, and administrators organize the process.
+
+## Repository Structure
+
+- `frontend/` – React + TypeScript application
+- `backend/` – FastAPI server (initial skeleton)
+
+## Development
+
+The frontend uses Vite and Tailwind CSS. The backend runs FastAPI and PostgreSQL via Docker Compose.
+
+```bash
+# Start backend
+cd backend
+cp .env.example .env
+docker-compose up --build
+```
+
+```bash
+# Start frontend
+cd frontend
+npm install
+npm run dev
+```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and fill the values
+DATABASE_URL=postgresql://user:password@db:5432/app_db
+JWT_SECRET=change_me

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,14 @@
+# Backend
+
+This directory contains the FastAPI backend for **Proje Çağrısı Değerlendirme Platformu**.
+
+## Quickstart
+
+```bash
+# Build and run the app with Docker
+cd backend
+cp .env.example .env
+docker-compose up --build
+```
+
+The API will be available at `http://localhost:8000`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"message": "Hello from FastAPI"}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    ports:
+      - '8000:8000'
+    env_file:
+      - .env
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app_db
+    ports:
+      - '5432:5432'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+


### PR DESCRIPTION
## Summary
- add project README with setup instructions
- add FastAPI backend skeleton and Docker setup

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68489f6b54fc832c9c84845b3e1633ec