### PR TITLE
Implement JWT login

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,4 +11,5 @@ async def root():
 
 
 app.include_router(users.router)
+app.include_router(users.auth_router)
 

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -1,11 +1,20 @@
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
+from jose import jwt, JWTError
+from passlib.context import CryptContext
 
 from ..database import SessionLocal, Base, engine
-from ..schemas.user import UserCreate, UserOut
+from ..schemas.user import UserCreate, UserOut, UserLogin
 from ..crud.user import get_user_by_email, create_user
+from ..models.user import User
+from ..config import settings
 
 router = APIRouter(prefix="/users", tags=["users"])
+auth_router = APIRouter()
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
 
 # Ensure tables created (simplified)
 Base.metadata.create_all(bind=engine)
@@ -17,9 +26,40 @@ def get_db():
     finally:
         db.close()
 
+def create_access_token(data: dict) -> str:
+    return jwt.encode(data, settings.jwt_secret, algorithm="HS256")
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
+) -> User:
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=["HS256"])
+        user_id = int(payload.get("sub"))
+    except (JWTError, TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    return user
+
 @router.post("/", response_model=UserOut)
 def register_user(user_in: UserCreate, db: Session = Depends(get_db)):
     if get_user_by_email(db, user_in.email):
         raise HTTPException(status_code=400, detail="Email already registered")
     user = create_user(db, user_in)
     return user
+
+
+@auth_router.post("/login")
+def login(user_in: UserLogin, db: Session = Depends(get_db)):
+    user = get_user_by_email(db, user_in.email)
+    if not user or not pwd_context.verify(user_in.password, user.hashed_password):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token({"sub": str(user.id)})
+    return {"access_token": token}
+
+
+@router.get("/me", response_model=UserOut)
+def read_current_user(current_user: User = Depends(get_current_user)):
+    return current_user

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -4,6 +4,10 @@ class UserCreate(BaseModel):
     email: EmailStr
     password: str
 
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
 class UserOut(BaseModel):
     id: int
     email: EmailStr


### PR DESCRIPTION
## Summary
- add `UserLogin` schema
- support logging in via `/login`
- sign JWT tokens with `settings.jwt_secret`
- protect a `/users/me` endpoint with token auth

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848a1e08bd8832cb7b69ba49aa633d9