### PR TITLE
Implement role enum and admin placeholders

### DIFF
--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 from passlib.context import CryptContext
 
-from ..models.user import User
+from ..models.user import User, UserRole
 from ..schemas.user import UserCreate
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -11,7 +11,8 @@ def get_user_by_email(db: Session, email: str):
 
 def create_user(db: Session, user_in: UserCreate) -> User:
     hashed_password = pwd_context.hash(user_in.password)
-    user = User(email=user_in.email, hashed_password=hashed_password)
+    role = UserRole(user_in.role)
+    user = User(email=user_in.email, hashed_password=hashed_password, role=role)
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,18 @@
+from fastapi import Depends, HTTPException, status
+
+from .models.user import User, UserRole
+
+
+def get_current_user() -> User:
+    """Placeholder returning the authenticated user."""
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authentication not implemented",
+    )
+
+
+def get_current_admin(current_user: User = Depends(get_current_user)) -> User:
+    """Placeholder dependency to ensure the current user is an admin."""
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough privileges")
+    return current_user

--- a/backend/app/migrations/0001_initial.py
+++ b/backend/app/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, Integer, String, Enum, MetaData, Table
+
+from ..database import engine
+from ..models.user import UserRole
+
+metadata = MetaData()
+
+users = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("email", String, unique=True, index=True, nullable=False),
+    Column("hashed_password", String, nullable=False),
+    Column(
+        "role",
+        Enum(UserRole, name="user_role"),
+        nullable=False,
+        server_default=UserRole.APPLICANT.value,
+    ),
+)
+
+
+def upgrade():
+    metadata.create_all(engine)
+
+
+def downgrade():
+    metadata.drop_all(engine)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,5 +1,14 @@
-from sqlalchemy import Column, Integer, String
+from enum import Enum as PyEnum
+
+from sqlalchemy import Column, Integer, String, Enum
+
 from ..database import Base
+
+
+class UserRole(PyEnum):
+    APPLICANT = "applicant"
+    REVIEWER = "reviewer"
+    ADMIN = "admin"
 
 class User(Base):
     __tablename__ = 'users'
@@ -7,4 +16,8 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
-    role = Column(String, nullable=False, default='applicant')
+    role = Column(
+        Enum(UserRole, name="user_role"),
+        nullable=False,
+        default=UserRole.APPLICANT,
+    )

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -19,6 +19,7 @@ def get_db():
 
 @router.post("/", response_model=UserOut)
 def register_user(user_in: UserCreate, db: Session = Depends(get_db)):
+    """Register a new user with the provided role."""
     if get_user_by_email(db, user_in.email):
         raise HTTPException(status_code=400, detail="Email already registered")
     user = create_user(db, user_in)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,13 +1,21 @@
+from enum import Enum
+
 from pydantic import BaseModel, EmailStr
+
+class UserRole(str, Enum):
+    applicant = "applicant"
+    reviewer = "reviewer"
+    admin = "admin"
 
 class UserCreate(BaseModel):
     email: EmailStr
     password: str
+    role: UserRole = UserRole.applicant
 
 class UserOut(BaseModel):
     id: int
     email: EmailStr
-    role: str
+    role: UserRole
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- add `UserRole` enum and migrate user `role` column
- expand user schemas with role field
- support role in registration logic
- create placeholder auth dependencies
- add initial migration script for table creation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848a1e2c8f0832ca8c66c91b61478a1