### PR TITLE
Add project call and application features

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ docker-compose up --build
 
 The API exposes a `/users/` endpoint to register new users. The sample `.env` file points the backend to the local Postgres container.
 
+Additional endpoints:
+
+- `POST /calls/` &mdash; create a new project call (admin only).
+- `POST /applications/` &mdash; submit an application to a call.
+
 ```bash
 # Start frontend
 cd frontend

--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -1,0 +1,16 @@
+from sqlalchemy.orm import Session
+
+from ..models.application import Application
+from ..models.call import Call
+from ..schemas.application import ApplicationCreate
+
+
+def create_application(db: Session, app_in: ApplicationCreate) -> Application:
+    call = db.query(Call).filter(Call.id == app_in.call_id).first()
+    if not call or not call.is_open:
+        raise ValueError("Call not available")
+    application = Application(user_id=app_in.user_id, call_id=app_in.call_id, content=app_in.content)
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application

--- a/backend/app/crud/call.py
+++ b/backend/app/crud/call.py
@@ -1,0 +1,16 @@
+from sqlalchemy.orm import Session
+
+from ..models.call import Call
+from ..schemas.call import CallCreate
+
+
+def create_call(db: Session, call_in: CallCreate) -> Call:
+    call = Call(title=call_in.title, description=call_in.description, is_open=call_in.is_open)
+    db.add(call)
+    db.commit()
+    db.refresh(call)
+    return call
+
+
+def get_call(db: Session, call_id: int) -> Call | None:
+    return db.query(Call).filter(Call.id == call_id).first()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 
 from .routes import users
+from .routes import calls, applications
 
 app = FastAPI()
 
@@ -11,4 +12,6 @@ async def root():
 
 
 app.include_router(users.router)
+app.include_router(calls.router)
+app.include_router(applications.router)
 

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, Text, ForeignKey
+
+from ..database import Base
+
+
+class Application(Base):
+    __tablename__ = "applications"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    call_id = Column(Integer, ForeignKey("calls.id"), nullable=False)
+    content = Column(Text, nullable=False)

--- a/backend/app/models/call.py
+++ b/backend/app/models/call.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, Text, Boolean
+
+from ..database import Base
+
+
+class Call(Base):
+    __tablename__ = "calls"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    description = Column(Text)
+    is_open = Column(Boolean, default=True)

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..database import SessionLocal, Base, engine
+from ..schemas.application import ApplicationCreate, ApplicationOut
+from ..crud.application import create_application
+
+router = APIRouter(prefix="/applications", tags=["applications"])
+
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=ApplicationOut)
+def submit_application(app_in: ApplicationCreate, db: Session = Depends(get_db)):
+    try:
+        application = create_application(db, app_in)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return application

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from ..database import SessionLocal, Base, engine
+from ..models.user import User
+from ..schemas.call import CallCreate, CallOut
+from ..crud.call import create_call
+
+router = APIRouter(prefix="/calls", tags=["calls"])
+
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=CallOut)
+def create_new_call(call_in: CallCreate, admin_id: int = Query(...), db: Session = Depends(get_db)):
+    admin = db.query(User).filter(User.id == admin_id).first()
+    if not admin or admin.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin only")
+    call = create_call(db, call_in)
+    return call

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+
+class ApplicationCreate(BaseModel):
+    user_id: int
+    call_id: int
+    content: str
+
+
+class ApplicationOut(BaseModel):
+    id: int
+    user_id: int
+    call_id: int
+    content: str
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/call.py
+++ b/backend/app/schemas/call.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+
+class CallCreate(BaseModel):
+    title: str
+    description: str | None = None
+    is_open: bool | None = True
+
+
+class CallOut(BaseModel):
+    id: int
+    title: str
+    description: str | None = None
+    is_open: bool
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- implement `Call` and `Application` models
- add Pydantic schemas and CRUD helpers
- expose `/calls/` and `/applications/` routes
- register new routers in FastAPI app
- document the new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a1e5ef54832cb016a760e9009df8