### PR TITLE
Add basic auth forms

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "@hookform/resolvers": "^3.3.1",
+        "react-hook-form": "^7.50.1",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,10 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@hookform/resolvers": "^3.3.1",
+    "react-hook-form": "^7.50.1",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,15 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import RegisterForm from './RegisterForm';
+import LoginForm from './LoginForm';
+import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1 className="text-3xl font-bold text-blue-600">Vite + React</h1>
-      <div className="card">
-        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="max-w-md mx-auto p-4 space-y-8">
+      <h1 className="text-2xl font-bold text-center">Project Call Platform</h1>
+      <RegisterForm />
+      <LoginForm />
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -1,0 +1,42 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { login, storeToken, LoginData } from './api';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: LoginData) => {
+    const res = await login(data);
+    storeToken(res.access_token);
+    alert('Logged in!');
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <h2 className="text-xl font-bold">Login</h2>
+      <div>
+        <input {...register('email')} placeholder="Email" className="border p-2 w-full" />
+        {errors.email && <p className="text-red-600">{errors.email.message}</p>}
+      </div>
+      <div>
+        <input {...register('password')} type="password" placeholder="Password" className="border p-2 w-full" />
+        {errors.password && <p className="text-red-600">{errors.password.message}</p>}
+      </div>
+      <button disabled={isSubmitting} className="bg-green-500 text-white px-4 py-2 rounded">
+        Login
+      </button>
+    </form>
+  );
+}
+
+export default LoginForm;

--- a/frontend/src/RegisterForm.tsx
+++ b/frontend/src/RegisterForm.tsx
@@ -1,0 +1,46 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { registerUser, RegisterData } from './api';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+  role: z.string().min(1),
+});
+
+function RegisterForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: RegisterData) => {
+    await registerUser(data);
+    alert('Registered successfully');
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <h2 className="text-xl font-bold">Register</h2>
+      <div>
+        <input {...register('email')} placeholder="Email" className="border p-2 w-full" />
+        {errors.email && <p className="text-red-600">{errors.email.message}</p>}
+      </div>
+      <div>
+        <input {...register('password')} type="password" placeholder="Password" className="border p-2 w-full" />
+        {errors.password && <p className="text-red-600">{errors.password.message}</p>}
+      </div>
+      <div>
+        <input {...register('role')} placeholder="Role" className="border p-2 w-full" />
+        {errors.role && <p className="text-red-600">{errors.role.message}</p>}
+      </div>
+      <button disabled={isSubmitting} className="bg-blue-500 text-white px-4 py-2 rounded">
+        Register
+      </button>
+    </form>
+  );
+}
+
+export default RegisterForm;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,44 @@
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+
+export interface RegisterData {
+  email: string;
+  password: string;
+  role: string;
+}
+
+export interface LoginData {
+  email: string;
+  password: string;
+}
+
+export async function registerUser(data: RegisterData) {
+  const res = await fetch(`${API_BASE}/users/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to register');
+  }
+  return res.json();
+}
+
+export async function login(data: LoginData) {
+  const res = await fetch(`${API_BASE}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to login');
+  }
+  return res.json();
+}
+
+export function storeToken(token: string) {
+  localStorage.setItem('token', token);
+}
+
+export function getToken() {
+  return localStorage.getItem('token');
+}


### PR DESCRIPTION
## Summary
- set up API helpers for registering and logging in
- create login and register forms using react-hook-form and zod
- keep JWT token in local storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react-hook-form')*

------
https://chatgpt.com/codex/tasks/task_e_6848a48d73ec832cac72c3409fa18843