### PR TITLE
Add login route to FastAPI app

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ async def root():
 
 
 app.include_router(users.router)
+app.include_router(users.auth_router)
 app.include_router(calls.router)
 app.include_router(applications.router)
 


### PR DESCRIPTION
## Summary
- include auth router in the FastAPI application

## Testing
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a626a434832cb900a7b613657248