### PR TITLE
Update settings library

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,5 +7,4 @@ passlib[bcrypt]
 python-jose[cryptography]
 psycopg2-binary
 alembic
-
-
+pydantic-settings


### PR DESCRIPTION
## Summary
- use `pydantic-settings` for configuration
- include `pydantic-settings` package in backend requirements

## Testing
- `docker-compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848afb76b80832cba03f08a99c351f5