### PR TITLE
Update pydantic dependency with email extras

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn[standard]
 sqlalchemy>=2.0
-pydantic>=2.7
+pydantic[email]>=2.7
 python-dotenv
 passlib[bcrypt]
 python-jose[cryptography]


### PR DESCRIPTION
## Summary
- request the `email` extras for pydantic so email validation works out of the box

## Testing
- `docker-compose up --build` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b1369068832c99aedaf356c568ff