### PR TITLE
Enable CORS for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ cp .env.example .env
 docker-compose up --build
 ```
 
+The `.env` file now also includes an `ALLOWED_ORIGINS` variable used for CORS. By default it allows requests from `http://localhost:5173`.
+
 The API exposes a `/users/` endpoint to register new users. The sample `.env` file points the backend to the local Postgres container.
 
 Additional endpoints:

--- a/backend/.env
+++ b/backend/.env
@@ -1,3 +1,4 @@
 
 DATABASE_URL=postgresql://user:password@db:5432/app_db
 JWT_SECRET=6161
+ALLOWED_ORIGINS=http://localhost:5173

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 
 DATABASE_URL=postgresql://user:password@db:5432/app_db
 JWT_SECRET=6161
+ALLOWED_ORIGINS=http://localhost:5173

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     database_url: str
     jwt_secret: str
+    allowed_origins: str = "*"
 
     class Config:
         env_file = '.env'

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,20 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 
 from .routes import users
 from .routes import calls, applications
+from .config import settings
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[origin.strip() for origin in settings.allowed_origins.split(',')],
+    allow_credentials=True,
+    allow_methods=["*"] ,
+    allow_headers=["*"] ,
+)
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
## Summary
- configure allowed origins in `Settings`
- add `CORSMiddleware` to FastAPI app
- document new `ALLOWED_ORIGINS` env var

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848b208c6c4832c8ec3f2a3fa57a193