### PR TITLE
Improve auth forms with dropdown role and toast alerts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,17 @@
 import RegisterForm from './RegisterForm';
 import LoginForm from './LoginForm';
+import { ToastProvider } from './ToastProvider';
 import './App.css';
 
 function App() {
   return (
-    <div className="max-w-md mx-auto p-4 space-y-8">
-      <h1 className="text-2xl font-bold text-center">Project Call Platform</h1>
-      <RegisterForm />
-      <LoginForm />
-    </div>
+    <ToastProvider>
+      <div className="max-w-md mx-auto p-4 space-y-8">
+        <h1 className="text-2xl font-bold text-center">Project Call Platform</h1>
+        <RegisterForm />
+        <LoginForm />
+      </div>
+    </ToastProvider>
   );
 }
 

--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { login, storeToken } from './api';
 import type { LoginData } from './api';
+import { useToast } from './ToastProvider';
 
 
 const schema = z.object({
@@ -16,11 +17,12 @@ function LoginForm() {
     handleSubmit,
     formState: { errors, isSubmitting },
   } = useForm<LoginData>({ resolver: zodResolver(schema) });
+  const { showToast } = useToast();
 
   const onSubmit = async (data: LoginData) => {
     const res = await login(data);
     storeToken(res.access_token);
-    alert('Logged in!');
+    showToast('Logged in!', 'success');
   };
 
   return (
@@ -33,6 +35,14 @@ function LoginForm() {
       <div>
         <input {...register('password')} type="password" placeholder="Password" className="border p-2 w-full" />
         {errors.password && <p className="text-red-600">{errors.password.message}</p>}
+      </div>
+      <div>
+        <select className="border p-2 w-full">
+          <option value="">Select role</option>
+          <option value="applicant">Applicant</option>
+          <option value="reviewer">Reviewer</option>
+          <option value="admin">Admin</option>
+        </select>
       </div>
       <button disabled={isSubmitting} className="bg-green-500 text-white px-4 py-2 rounded">
         Login

--- a/frontend/src/RegisterForm.tsx
+++ b/frontend/src/RegisterForm.tsx
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { registerUser } from './api';
 import type { RegisterData } from './api';
+import { useToast } from './ToastProvider';
 
 
 const schema = z.object({
@@ -17,10 +18,11 @@ function RegisterForm() {
     handleSubmit,
     formState: { errors, isSubmitting },
   } = useForm<RegisterData>({ resolver: zodResolver(schema) });
+  const { showToast } = useToast();
 
   const onSubmit = async (data: RegisterData) => {
     await registerUser(data);
-    alert('Registered successfully');
+    showToast('Registered successfully', 'success');
   };
 
   return (
@@ -35,7 +37,12 @@ function RegisterForm() {
         {errors.password && <p className="text-red-600">{errors.password.message}</p>}
       </div>
       <div>
-        <input {...register('role')} placeholder="Role" className="border p-2 w-full" />
+        <select {...register('role')} className="border p-2 w-full">
+          <option value="">Select role</option>
+          <option value="applicant">Applicant</option>
+          <option value="reviewer">Reviewer</option>
+          <option value="admin">Admin</option>
+        </select>
         {errors.role && <p className="text-red-600">{errors.role.message}</p>}
       </div>
       <button disabled={isSubmitting} className="bg-blue-500 text-white px-4 py-2 rounded">

--- a/frontend/src/ToastProvider.tsx
+++ b/frontend/src/ToastProvider.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+type ToastType = 'success' | 'error';
+
+interface ToastContextValue {
+  showToast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({
+  showToast: () => {},
+});
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toast, setToast] = useState<{ message: string; type: ToastType } | null>(null);
+
+  const showToast = (message: string, type: ToastType = 'success') => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {toast && (
+        <div
+          className={`fixed top-4 right-4 px-4 py-2 rounded shadow text-white ${
+            toast.type === 'success' ? 'bg-green-500' : 'bg-red-500'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </ToastContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add ToastProvider component for custom success/error alerts
- wrap application in the provider
- use toasts instead of `alert()` in register and login forms
- replace free-text role in registration with a dropdown
- show same dropdown in login (not used in request)

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6848b6c092d0832c91cb80b92ad84ab7