### PR TITLE
Add call listing routes and frontend display

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Additional endpoints:
 
 - `POST /calls/` &mdash; create a new project call (admin only).
 - `POST /applications/` &mdash; submit an application to a call.
+- `GET /calls/` &mdash; list all calls (optionally filter by open ones).
+- `GET /calls/{id}` &mdash; get details for a specific call.
 
 ```bash
 # Start frontend

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -3,8 +3,9 @@ from sqlalchemy.orm import Session
 
 from ..database import SessionLocal, Base, engine
 from ..models.user import User
+from ..models.call import Call
 from ..schemas.call import CallCreate, CallOut
-from ..crud.call import create_call
+from ..crud.call import create_call, get_call
 
 router = APIRouter(prefix="/calls", tags=["calls"])
 
@@ -25,4 +26,21 @@ def create_new_call(call_in: CallCreate, admin_id: int = Query(...), db: Session
     if not admin or admin.role != "admin":
         raise HTTPException(status_code=403, detail="Admin only")
     call = create_call(db, call_in)
+    return call
+
+
+@router.get("/", response_model=list[CallOut])
+def list_calls(only_open: bool = False, db: Session = Depends(get_db)):
+    """Return all calls. Optionally filter by open status."""
+    query = db.query(Call)
+    if only_open:
+        query = query.filter(Call.is_open == True)  # noqa: E712
+    return query.all()
+
+
+@router.get("/{call_id}", response_model=CallOut)
+def read_call(call_id: int, db: Session = Depends(get_db)):
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
     return call

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import RegisterForm from './RegisterForm';
 import LoginForm from './LoginForm';
+import CallList from './CallList';
 import { ToastProvider } from './ToastProvider';
 import './App.css';
 
@@ -10,6 +11,7 @@ function App() {
         <h1 className="text-2xl font-bold text-center">Project Call Platform</h1>
         <RegisterForm />
         <LoginForm />
+        <CallList />
       </div>
     </ToastProvider>
   );

--- a/frontend/src/CallList.tsx
+++ b/frontend/src/CallList.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { fetchCalls, Call } from './api';
+import { useToast } from './ToastProvider';
+
+function CallList() {
+  const [calls, setCalls] = useState<Call[]>([]);
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    fetchCalls(true)
+      .then(setCalls)
+      .catch(() => showToast('Failed to load calls', 'error'));
+  }, [showToast]);
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xl font-bold">Open Calls</h2>
+      <ul className="list-disc list-inside">
+        {calls.map((c) => (
+          <li key={c.id}>
+            <div className="font-semibold">{c.title}</div>
+            {c.description && <p className="text-sm">{c.description}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default CallList;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -42,3 +42,20 @@ export function storeToken(token: string) {
 export function getToken() {
   return localStorage.getItem('token');
 }
+
+export interface Call {
+  id: number;
+  title: string;
+  description?: string;
+  is_open: boolean;
+}
+
+export async function fetchCalls(onlyOpen = false): Promise<Call[]> {
+  const url = new URL(`${API_BASE}/calls/`);
+  if (onlyOpen) url.searchParams.set('only_open', 'true');
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch calls');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- extend FastAPI calls router with list and detail endpoints
- document new API endpoints in README
- show calls on frontend and expose call-fetching API utility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848b7fb4b60832c8127dd2a14303ebd