### PR TITLE
Add accessible form labels

### DIFF
--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -29,20 +29,40 @@ function LoginForm() {
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
       <h2 className="text-xl font-bold">Login</h2>
       <div>
-        <input {...register('email')} placeholder="Email" className="border p-2 w-full" />
+        <label htmlFor="login-email" className="block">
+          Email
+          <input
+            id="login-email"
+            {...register('email')}
+            placeholder="Email"
+            className="border p-2 w-full"
+          />
+        </label>
         {errors.email && <p className="text-red-600">{errors.email.message}</p>}
       </div>
       <div>
-        <input {...register('password')} type="password" placeholder="Password" className="border p-2 w-full" />
+        <label htmlFor="login-password" className="block">
+          Password
+          <input
+            id="login-password"
+            {...register('password')}
+            type="password"
+            placeholder="Password"
+            className="border p-2 w-full"
+          />
+        </label>
         {errors.password && <p className="text-red-600">{errors.password.message}</p>}
       </div>
       <div>
-        <select className="border p-2 w-full">
-          <option value="">Select role</option>
-          <option value="applicant">Applicant</option>
-          <option value="reviewer">Reviewer</option>
-          <option value="admin">Admin</option>
-        </select>
+        <label htmlFor="login-role" className="block">
+          Role
+          <select id="login-role" className="border p-2 w-full">
+            <option value="">Select role</option>
+            <option value="applicant">Applicant</option>
+            <option value="reviewer">Reviewer</option>
+            <option value="admin">Admin</option>
+          </select>
+        </label>
       </div>
       <button disabled={isSubmitting} className="bg-green-500 text-white px-4 py-2 rounded">
         Login

--- a/frontend/src/RegisterForm.tsx
+++ b/frontend/src/RegisterForm.tsx
@@ -29,20 +29,44 @@ function RegisterForm() {
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
       <h2 className="text-xl font-bold">Register</h2>
       <div>
-        <input {...register('email')} placeholder="Email" className="border p-2 w-full" />
+        <label htmlFor="register-email" className="block">
+          Email
+          <input
+            id="register-email"
+            {...register('email')}
+            placeholder="Email"
+            className="border p-2 w-full"
+          />
+        </label>
         {errors.email && <p className="text-red-600">{errors.email.message}</p>}
       </div>
       <div>
-        <input {...register('password')} type="password" placeholder="Password" className="border p-2 w-full" />
+        <label htmlFor="register-password" className="block">
+          Password
+          <input
+            id="register-password"
+            {...register('password')}
+            type="password"
+            placeholder="Password"
+            className="border p-2 w-full"
+          />
+        </label>
         {errors.password && <p className="text-red-600">{errors.password.message}</p>}
       </div>
       <div>
-        <select {...register('role')} className="border p-2 w-full">
-          <option value="">Select role</option>
-          <option value="applicant">Applicant</option>
-          <option value="reviewer">Reviewer</option>
-          <option value="admin">Admin</option>
-        </select>
+        <label htmlFor="register-role" className="block">
+          Role
+          <select
+            id="register-role"
+            {...register('role')}
+            className="border p-2 w-full"
+          >
+            <option value="">Select role</option>
+            <option value="applicant">Applicant</option>
+            <option value="reviewer">Reviewer</option>
+            <option value="admin">Admin</option>
+          </select>
+        </label>
         {errors.role && <p className="text-red-600">{errors.role.message}</p>}
       </div>
       <button disabled={isSubmitting} className="bg-blue-500 text-white px-4 py-2 rounded">


### PR DESCRIPTION
## Summary
- improve accessibility of register and login forms by wrapping each field in a descriptive `<label>`
- assign `htmlFor` and `id` attributes so screen readers associate labels with their inputs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684937a61608832c872fc36e6eb1f47e