### PR TITLE
Add role selection to login workflow

### DIFF
--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -56,7 +56,9 @@ def login(user_in: UserLogin, db: Session = Depends(get_db)):
     user = get_user_by_email(db, user_in.email)
     if not user or not pwd_context.verify(user_in.password, user.hashed_password):
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = create_access_token({"sub": str(user.id)})
+    if user.role.value != user_in.role:
+        raise HTTPException(status_code=403, detail="Role mismatch")
+    token = create_access_token({"sub": str(user.id), "role": user_in.role})
     return {"access_token": token}
 
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -15,6 +15,7 @@ class UserCreate(BaseModel):
 class UserLogin(BaseModel):
     email: EmailStr
     password: str
+    role: UserRole
 
 class UserOut(BaseModel):
     id: int

--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -64,17 +64,6 @@ function LoginForm() {
         </label>
         {errors.password && <p className="text-red-600">{errors.password.message}</p>}
       </div>
-      <div>
-        <label htmlFor="login-role" className="block">
-          Role
-          <select id="login-role" className="border p-2 w-full">
-            <option value="">Select role</option>
-            <option value="applicant">Applicant</option>
-            <option value="reviewer">Reviewer</option>
-            <option value="admin">Admin</option>
-          </select>
-        </label>
-      </div>
       <button disabled={isSubmitting} className="bg-green-500 text-white px-4 py-2 rounded">
         Next
       </button>


### PR DESCRIPTION
## Summary
- include role in `UserLogin` schema
- verify chosen role on `/login` and add it to the generated token
- clean up `LoginForm` to use the slider on a second step

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68494e029368832cb6ebfc0f45658aa5