### PR TITLE
Fix Role import type

### DIFF
--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -5,7 +5,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { login, storeToken } from './api';
 import type { LoginData } from './api';
 import { useToast } from './ToastProvider';
-import RoleSlider, { Role } from './RoleSlider';
+import RoleSlider from './RoleSlider';
+import type { Role } from './RoleSlider';
 
 
 const schema = z.object({


### PR DESCRIPTION
## Summary
- split Role import to be type-only in `LoginForm.tsx`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68495022e3a4832c9e4e2fbed3601134