### PR TITLE
Enable optional table creation via FastAPI startup

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -2,3 +2,4 @@
 DATABASE_URL=postgresql://user:password@db:5432/app_db
 JWT_SECRET=6161
 ALLOWED_ORIGINS=http://localhost:5173
+CREATE_TABLES=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,4 @@
 DATABASE_URL=postgresql://user:password@db:5432/app_db
 JWT_SECRET=6161
 ALLOWED_ORIGINS=http://localhost:5173
+CREATE_TABLES=true

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,6 +4,7 @@ class Settings(BaseSettings):
     database_url: str
     jwt_secret: str
     allowed_origins: str = "*"
+    create_tables: bool = False
 
     class Config:
         env_file = '.env'

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,8 +5,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from .routes import users
 from .routes import calls, applications
 from .config import settings
+from .database import Base, engine
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    if settings.create_tables:
+        Base.metadata.create_all(bind=engine)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -1,13 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from ..database import SessionLocal, Base, engine
+from ..database import SessionLocal
 from ..schemas.application import ApplicationCreate, ApplicationOut
 from ..crud.application import create_application
 
 router = APIRouter(prefix="/applications", tags=["applications"])
-
-Base.metadata.create_all(bind=engine)
 
 
 def get_db():

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -1,15 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from ..database import SessionLocal, Base, engine
+from ..database import SessionLocal
 from ..models.user import User
 from ..models.call import Call
 from ..schemas.call import CallCreate, CallOut
 from ..crud.call import create_call, get_call
 
 router = APIRouter(prefix="/calls", tags=["calls"])
-
-Base.metadata.create_all(bind=engine)
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- add `create_tables` option to backend settings
- initialize tables in a FastAPI startup event
- remove direct `create_all` calls from route modules
- document the new setting in `.env` examples

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684963dad354832c89282d02386e5feb