### PR TITLE
Implement JWT auth dependencies

### DIFF
--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from ..dependencies import get_current_user
+from ..models.user import User
+
 from ..database import SessionLocal, Base, engine
 from ..schemas.application import ApplicationCreate, ApplicationOut
 from ..crud.application import create_application
@@ -19,7 +22,11 @@ def get_db():
 
 
 @router.post("/", response_model=ApplicationOut)
-def submit_application(app_in: ApplicationCreate, db: Session = Depends(get_db)):
+def submit_application(
+    app_in: ApplicationCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     try:
         application = create_application(db, app_in)
     except ValueError as exc:

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from ..database import SessionLocal, Base, engine
+from ..dependencies import get_current_admin
 from ..models.user import User
 from ..models.call import Call
 from ..schemas.call import CallCreate, CallOut
@@ -21,10 +22,11 @@ def get_db():
 
 
 @router.post("/", response_model=CallOut)
-def create_new_call(call_in: CallCreate, admin_id: int = Query(...), db: Session = Depends(get_db)):
-    admin = db.query(User).filter(User.id == admin_id).first()
-    if not admin or admin.role != "admin":
-        raise HTTPException(status_code=403, detail="Admin only")
+def create_new_call(
+    call_in: CallCreate,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin),
+):
     call = create_call(db, call_in)
     return call
 


### PR DESCRIPTION
## Summary
- add JWT-based authentication helpers
- update `calls`, `applications`, and `users` routes to use shared dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684963deead0832ca49cbff75cb803c0