### PR TITLE
Add tables for calls and applications

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,22 @@ docker-compose up --build
 
 The API will be available at `http://localhost:8000`.
 
+### Database migrations
+
+The project uses Alembic for managing schema migrations. Set your
+`DATABASE_URL` in `.env` and then run the migrations:
+
+```bash
+# From the `backend` directory
+alembic upgrade head
+```
+
+When using Docker you can run the command inside the API container:
+
+```bash
+docker-compose run --rm api alembic upgrade head
+```
+
 ### Authentication
 
 Send a POST request to `/login` with `email` and `password`. After entering

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,12 @@
+
+"""Import all ORM models so Alembic can discover them."""
+
+from .user import User  # noqa: F401
+from .call import Call  # noqa: F401
+from .application import Application  # noqa: F401
+
+__all__ = [
+    "User",
+    "Call",
+    "Application",
+]

--- a/backend/migrations/versions/0002_create_calls_table.py
+++ b/backend/migrations/versions/0002_create_calls_table.py
@@ -1,0 +1,30 @@
+"""create calls table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2025-06-11 00:01:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'calls',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.Text()),
+        sa.Column('is_open', sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.create_index('ix_calls_id', 'calls', ['id'])
+
+
+def downgrade():
+    op.drop_index('ix_calls_id', table_name='calls')
+    op.drop_table('calls')

--- a/backend/migrations/versions/0003_create_applications_table.py
+++ b/backend/migrations/versions/0003_create_applications_table.py
@@ -1,0 +1,30 @@
+"""create applications table
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2025-06-11 00:02:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'applications',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('call_id', sa.Integer(), sa.ForeignKey('calls.id'), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+    )
+    op.create_index('ix_applications_id', 'applications', ['id'])
+
+
+def downgrade():
+    op.drop_index('ix_applications_id', table_name='applications')
+    op.drop_table('applications')


### PR DESCRIPTION
## Summary
- add calls & applications Alembic migrations
- expose ORM models for Alembic metadata
- document how to run migrations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684968172b58832cbca2208b7e1b4b12