### PR TITLE
Use shared get_db dependency

### DIFF
--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -1,21 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from app.dependencies import get_db
 from ..dependencies import get_current_user
 from ..models.user import User
-from ..database import SessionLocal, Base, engine
 from ..schemas.application import ApplicationCreate, ApplicationOut
 from ..crud.application import create_application
 
 router = APIRouter(prefix="/applications", tags=["applications"])
-
-
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 @router.post("/", response_model=ApplicationOut)

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from ..database import SessionLocal, Base, engine
+from app.dependencies import get_db
 from ..dependencies import get_current_admin
 from ..models.user import User
 
@@ -10,14 +10,6 @@ from ..schemas.call import CallCreate, CallOut
 from ..crud.call import create_call, get_call
 
 router = APIRouter(prefix="/calls", tags=["calls"])
-
-
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 @router.post("/", response_model=CallOut)

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -4,25 +4,17 @@ from jose import jwt
 from passlib.context import CryptContext
 
 
-from ..database import SessionLocal
+from app.dependencies import get_db
+from ..dependencies import get_current_user
 from ..schemas.user import UserCreate, UserOut, UserLogin
 from ..crud.user import get_user_by_email, create_user
 from ..models.user import User
-from ..dependencies import get_current_user
 from ..config import settings
 
 router = APIRouter(prefix="/users", tags=["users"])
 auth_router = APIRouter()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 def create_access_token(data: dict) -> str:
     return jwt.encode(data, settings.jwt_secret, algorithm="HS256")


### PR DESCRIPTION
## Summary
- use `app.dependencies.get_db` instead of local copies
- remove unused imports and redundant functions

## Testing
- `python -m compileall backend/app/routes`

------
https://chatgpt.com/codex/tasks/task_e_684968061e98832c94603312cbde642b