### PR TITLE
Improve home and calls pages

### DIFF
--- a/frontend/src/components/CallList.tsx
+++ b/frontend/src/components/CallList.tsx
@@ -14,16 +14,21 @@ function CallList() {
   }, [showToast]);
 
   return (
-    <div className="space-y-2">
-      <h2 className="text-xl font-bold">Open Calls</h2>
-      <ul className="list-disc list-inside">
-        {calls.map((c) => (
-          <li key={c.id}>
-            <div className="font-semibold">{c.title}</div>
-            {c.description && <p className="text-sm">{c.description}</p>}
-          </li>
-        ))}
-      </ul>
+    <div>
+      {calls.length === 0 ? (
+        <p>No open calls at the moment.</p>
+      ) : (
+        <ul className="grid gap-4">
+          {calls.map((c) => (
+            <li key={c.id} className="border rounded p-4 shadow bg-white">
+              <h3 className="text-lg font-semibold">{c.title}</h3>
+              {c.description && (
+                <p className="text-sm text-gray-700 mt-1">{c.description}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/CallsPage.tsx
+++ b/frontend/src/pages/CallsPage.tsx
@@ -1,5 +1,15 @@
 import CallList from '../components/CallList'
 
 export default function CallsPage() {
-  return <CallList />
+  return (
+    <section className="space-y-6">
+      <header className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">Current Project Calls</h1>
+        <p className="text-gray-600">
+          Find a project that interests you and submit your application.
+        </p>
+      </header>
+      <CallList />
+    </section>
+  )
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,10 +1,27 @@
-import React from 'react'
+import { Link } from 'react-router-dom'
 
 export default function HomePage() {
   return (
-    <div className="space-y-2">
-      <h2 className="text-xl font-bold">Welcome to Project Call Platform</h2>
-      <p>Use this platform to view and apply to project calls.</p>
-    </div>
+    <section className="text-center py-20 px-4 bg-gradient-to-b from-blue-50 via-white to-blue-50 space-y-6 rounded-lg shadow">
+      <h1 className="text-3xl font-extrabold">Welcome to Project Call Platform</h1>
+      <p className="max-w-xl mx-auto text-lg">
+        Discover new opportunities and collaborate on exciting projects.
+        Browse the latest calls or join our community by signing up.
+      </p>
+      <div className="space-x-4">
+        <Link
+          to="/calls"
+          className="bg-blue-600 text-white px-6 py-3 rounded shadow hover:bg-blue-700"
+        >
+          View Calls
+        </Link>
+        <Link
+          to="/register"
+          className="bg-green-600 text-white px-6 py-3 rounded shadow hover:bg-green-700"
+        >
+          Sign Up
+        </Link>
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- redesign the landing page with a hero section and action links
- enhance the calls page layout and style
- style the call list as a grid of cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684967140f08832c925df5235047ad57