### PR TITLE
Add auth helpers to API

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -44,6 +44,33 @@ export function getToken() {
   return localStorage.getItem('token');
 }
 
+export function logout() {
+  localStorage.removeItem('token');
+}
+
+function authHeaders() {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export interface ApplicationData {
+  user_id: number;
+  call_id: number;
+  content: string;
+}
+
+export async function submitApplication(data: ApplicationData) {
+  const res = await fetch(`${API_BASE}/applications/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to submit application');
+  }
+  return res.json();
+}
+
 export interface Call {
   id: number;
   title: string;


### PR DESCRIPTION
## Summary
- add logout utility and auth header helper
- implement `submitApplication` using stored token

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68496828c68c832c82dc993d0868e80d