### PR TITLE
Add attachment upload endpoint

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -14,3 +14,14 @@ def create_application(db: Session, call_id: int, content: str, user_id: int) ->
     db.commit()
     db.refresh(application)
     return application
+
+
+def get_application_by_user_and_call(
+    db: Session, user_id: int, call_id: int
+) -> Application | None:
+    """Return application for a given user and call."""
+    return (
+        db.query(Application)
+        .filter(Application.user_id == user_id, Application.call_id == call_id)
+        .first()
+    )

--- a/backend/app/crud/attachment.py
+++ b/backend/app/crud/attachment.py
@@ -1,0 +1,11 @@
+from sqlalchemy.orm import Session
+
+from ..models.attachment import Attachment
+
+
+def create_attachment(db: Session, application_id: int, file_path: str) -> Attachment:
+    attachment = Attachment(application_id=application_id, file_path=file_path)
+    db.add(attachment)
+    db.commit()
+    db.refresh(attachment)
+    return attachment

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,9 +4,11 @@
 from .user import User  # noqa: F401
 from .call import Call  # noqa: F401
 from .application import Application  # noqa: F401
+from .attachment import Attachment  # noqa: F401
 
 __all__ = [
     "User",
     "Call",
     "Application",
+    "Attachment",
 ]

--- a/backend/app/models/attachment.py
+++ b/backend/app/models/attachment.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+
+from ..database import Base
+
+
+class Attachment(Base):
+    __tablename__ = "attachments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    application_id = Column(Integer, ForeignKey("applications.id"), nullable=False)
+    file_path = Column(String, nullable=False)

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -1,11 +1,16 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
+from typing import List
+from pathlib import Path
+import shutil
 
 from app.dependencies import get_db
 from ..dependencies import get_current_user
 from ..models.user import User
 from ..schemas.application import ApplicationCreate, ApplicationOut
-from ..crud.application import create_application
+from ..schemas.attachment import AttachmentOut
+from ..crud.application import create_application, get_application_by_user_and_call
+from ..crud.attachment import create_attachment
 
 router = APIRouter(prefix="/applications", tags=["applications"])
 
@@ -23,3 +28,28 @@ def submit_application(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return application
+
+
+@router.post("/{call_id}/upload", response_model=list[AttachmentOut])
+def upload_application_files(
+    call_id: int,
+    files: List[UploadFile] = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Upload attachment files for the current user's application."""
+    application = get_application_by_user_and_call(db, current_user.id, call_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+
+    upload_dir = Path("uploads")
+    upload_dir.mkdir(exist_ok=True)
+
+    attachments = []
+    for uploaded_file in files:
+        file_location = upload_dir / uploaded_file.filename
+        with file_location.open("wb") as buffer:
+            shutil.copyfileobj(uploaded_file.file, buffer)
+        attachment = create_attachment(db, application.id, str(file_location))
+        attachments.append(attachment)
+    return attachments

--- a/backend/app/schemas/attachment.py
+++ b/backend/app/schemas/attachment.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class AttachmentOut(BaseModel):
+    id: int
+    application_id: int
+    file_path: str
+
+    class Config:
+        orm_mode = True

--- a/backend/migrations/versions/0004_create_attachments_table.py
+++ b/backend/migrations/versions/0004_create_attachments_table.py
@@ -1,0 +1,29 @@
+"""create attachments table
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2025-06-11 00:03:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'attachments',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('application_id', sa.Integer(), sa.ForeignKey('applications.id'), nullable=False),
+        sa.Column('file_path', sa.String(), nullable=False),
+    )
+    op.create_index('ix_attachments_id', 'attachments', ['id'])
+
+
+def downgrade():
+    op.drop_index('ix_attachments_id', table_name='attachments')
+    op.drop_table('attachments')


### PR DESCRIPTION
## Summary
- add `Attachment` model and schema
- create CRUD helpers for attachments
- implement `/applications/{call_id}/upload` endpoint
- add migration for attachments table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849d696aa78832c81d373824a016496