### PR TITLE
Add document preview page

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -25,3 +25,12 @@ def get_application_by_user_and_call(
         .filter(Application.user_id == user_id, Application.call_id == call_id)
         .first()
     )
+
+
+def confirm_documents(db: Session, application: Application) -> Application:
+    """Mark documents for an application as confirmed."""
+    application.documents_confirmed = True
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application

--- a/backend/app/crud/attachment.py
+++ b/backend/app/crud/attachment.py
@@ -9,3 +9,14 @@ def create_attachment(db: Session, application_id: int, file_path: str) -> Attac
     db.commit()
     db.refresh(attachment)
     return attachment
+
+
+def get_attachments_by_application(
+    db: Session, application_id: int
+) -> list[Attachment]:
+    """Return all attachments belonging to an application."""
+    return (
+        db.query(Attachment)
+        .filter(Attachment.application_id == application_id)
+        .all()
+    )

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Text, ForeignKey
+from sqlalchemy import Column, Integer, Text, ForeignKey, Boolean
 
 from ..database import Base
 
@@ -10,3 +10,4 @@ class Application(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     call_id = Column(Integer, ForeignKey("calls.id"), nullable=False)
     content = Column(Text, nullable=False)
+    documents_confirmed = Column(Boolean, default=False)

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -9,8 +9,12 @@ from ..dependencies import get_current_user
 from ..models.user import User
 from ..schemas.application import ApplicationCreate, ApplicationOut
 from ..schemas.attachment import AttachmentOut
-from ..crud.application import create_application, get_application_by_user_and_call
-from ..crud.attachment import create_attachment
+from ..crud.application import (
+    create_application,
+    get_application_by_user_and_call,
+    confirm_documents,
+)
+from ..crud.attachment import create_attachment, get_attachments_by_application
 
 router = APIRouter(prefix="/applications", tags=["applications"])
 
@@ -53,3 +57,30 @@ def upload_application_files(
         attachment = create_attachment(db, application.id, str(file_location))
         attachments.append(attachment)
     return attachments
+
+
+@router.get("/{call_id}/attachments", response_model=list[AttachmentOut])
+def list_application_files(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return attachment files for the current user's application."""
+    application = get_application_by_user_and_call(db, current_user.id, call_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return get_attachments_by_application(db, application.id)
+
+
+@router.post("/{call_id}/confirm")
+def confirm_application_documents(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Mark the current user's application documents as confirmed."""
+    application = get_application_by_user_and_call(db, current_user.id, call_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    confirm_documents(db, application)
+    return {"message": "Documents confirmed"}

--- a/backend/migrations/versions/0005_add_documents_confirmed_to_applications.py
+++ b/backend/migrations/versions/0005_add_documents_confirmed_to_applications.py
@@ -1,0 +1,21 @@
+"""add documents_confirmed column
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2025-06-11 00:04:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('applications', sa.Column('documents_confirmed', sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    op.drop_column('applications', 'documents_confirmed')

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import LoginPage from './pages/LoginPage'
 import CallsPage from './pages/CallsPage'
 import HomePage from './pages/HomePage'
 import AboutPage from './pages/AboutPage'
+import ApplicationPreview from './pages/ApplicationPreview'
 import { Routes, Route } from 'react-router-dom'
 
 
@@ -21,6 +22,7 @@ function App() {
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/calls" element={<CallsPage />} />
+            <Route path="/applications/:callId/preview" element={<ApplicationPreview />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -117,3 +117,30 @@ export async function uploadDocuments(
     xhr.send(data);
   });
 }
+
+export interface Attachment {
+  id: number;
+  application_id: number;
+  file_path: string;
+}
+
+export async function fetchApplicationDocuments(callId: number): Promise<Attachment[]> {
+  const res = await fetch(`${API_BASE}/applications/${callId}/attachments`, {
+    headers: { ...authHeaders() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch documents');
+  }
+  return res.json();
+}
+
+export async function confirmDocuments(callId: number) {
+  const res = await fetch(`${API_BASE}/applications/${callId}/confirm`, {
+    method: 'POST',
+    headers: { ...authHeaders() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to confirm documents');
+  }
+  return res.json();
+}

--- a/frontend/src/pages/ApplicationPreview.tsx
+++ b/frontend/src/pages/ApplicationPreview.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  fetchApplicationDocuments,
+  confirmDocuments,
+  type Attachment,
+} from '../api';
+import { useToast } from '../components/ToastProvider';
+
+export default function ApplicationPreview() {
+  const { callId } = useParams();
+  const [docs, setDocs] = useState<Attachment[]>([]);
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (!callId) return;
+    fetchApplicationDocuments(Number(callId))
+      .then(setDocs)
+      .catch(() => showToast('Failed to load documents', 'error'));
+  }, [callId, showToast]);
+
+  const onConfirm = async () => {
+    if (!callId) return;
+    try {
+      await confirmDocuments(Number(callId));
+      showToast('Documents confirmed', 'success');
+    } catch {
+      showToast('Failed to confirm documents', 'error');
+    }
+  };
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-xl font-bold">Uploaded Documents</h1>
+      {docs.length === 0 ? (
+        <p>No documents uploaded.</p>
+      ) : (
+        <ul className="list-disc pl-5 space-y-1">
+          {docs.map((d) => (
+            <li key={d.id}>
+              <a
+                href={`${import.meta.env.VITE_API_BASE || 'http://localhost:8000'}/${d.file_path}`}
+                className="text-blue-600 underline"
+              >
+                {d.file_path.split('/').pop()}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button
+        onClick={onConfirm}
+        className="bg-green-600 text-white px-4 py-2 rounded"
+      >
+        Confirm Documents
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- support listing and confirming application files in backend
- expose new API helpers to fetch and confirm documents
- create ApplicationPreview page to show uploaded files
- add route for the preview page
- track confirmed state in applications via migration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849d86d04c8832c9c8640d49059a234