### PR TITLE
Add endpoint to confirm application documents

### DIFF
--- a/backend/app/crud/attachment.py
+++ b/backend/app/crud/attachment.py
@@ -9,3 +9,28 @@ def create_attachment(db: Session, application_id: int, file_path: str) -> Attac
     db.commit()
     db.refresh(attachment)
     return attachment
+
+
+def get_attachments_by_application(db: Session, application_id: int) -> list[Attachment]:
+    return db.query(Attachment).filter(Attachment.application_id == application_id).all()
+
+
+def confirm_attachments(db: Session, application_id: int) -> None:
+    """Mark all attachments for an application as confirmed."""
+    db.query(Attachment).filter(Attachment.application_id == application_id).update(
+        {Attachment.is_confirmed: True}
+    )
+    db.commit()
+
+
+def attachments_confirmed(db: Session, application_id: int) -> bool:
+    """Return True if any attachment for application is confirmed."""
+    return (
+        db.query(Attachment)
+        .filter(
+            Attachment.application_id == application_id,
+            Attachment.is_confirmed == True,
+        )
+        .first()
+        is not None
+    )

--- a/backend/app/models/attachment.py
+++ b/backend/app/models/attachment.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, Boolean
 
 from ..database import Base
 
@@ -9,3 +9,4 @@ class Attachment(Base):
     id = Column(Integer, primary_key=True, index=True)
     application_id = Column(Integer, ForeignKey("applications.id"), nullable=False)
     file_path = Column(String, nullable=False)
+    is_confirmed = Column(Boolean, default=False)

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -10,7 +10,12 @@ from ..models.user import User
 from ..schemas.application import ApplicationCreate, ApplicationOut
 from ..schemas.attachment import AttachmentOut
 from ..crud.application import create_application, get_application_by_user_and_call
-from ..crud.attachment import create_attachment
+from ..crud.attachment import (
+    create_attachment,
+    confirm_attachments,
+    attachments_confirmed,
+    get_attachments_by_application,
+)
 
 router = APIRouter(prefix="/applications", tags=["applications"])
 
@@ -42,6 +47,9 @@ def upload_application_files(
     if not application:
         raise HTTPException(status_code=404, detail="Application not found")
 
+    if attachments_confirmed(db, application.id):
+        raise HTTPException(status_code=400, detail="Attachments already confirmed")
+
     upload_dir = Path("uploads")
     upload_dir.mkdir(exist_ok=True)
 
@@ -53,3 +61,25 @@ def upload_application_files(
         attachment = create_attachment(db, application.id, str(file_location))
         attachments.append(attachment)
     return attachments
+
+
+@router.post("/{call_id}/confirm")
+def confirm_application_files(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Confirm uploaded files for an application."""
+    application = get_application_by_user_and_call(db, current_user.id, call_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+
+    if attachments_confirmed(db, application.id):
+        raise HTTPException(status_code=400, detail="Attachments already confirmed")
+
+    attachments = get_attachments_by_application(db, application.id)
+    if not attachments:
+        raise HTTPException(status_code=400, detail="No attachments to confirm")
+
+    confirm_attachments(db, application.id)
+    return {"detail": "Attachments confirmed"}

--- a/backend/app/schemas/attachment.py
+++ b/backend/app/schemas/attachment.py
@@ -5,6 +5,7 @@ class AttachmentOut(BaseModel):
     id: int
     application_id: int
     file_path: str
+    is_confirmed: bool
 
     class Config:
         orm_mode = True

--- a/backend/migrations/versions/0005_add_is_confirmed_to_attachments.py
+++ b/backend/migrations/versions/0005_add_is_confirmed_to_attachments.py
@@ -1,0 +1,22 @@
+"""add is_confirmed column to attachments
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2025-06-11 00:04:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('attachments', sa.Column('is_confirmed', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('attachments', 'is_confirmed')
+


### PR DESCRIPTION
## Summary
- add `is_confirmed` field to `Attachment` model and schema
- create alembic migration to add field
- extend attachment CRUD with helper functions for confirmations
- block uploads when documents are confirmed and add `/applications/{call_id}/confirm` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d8678a78832caf3f7a20da4fd8fc