### PR TITLE
Add python-multipart dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ python-jose[cryptography]
 psycopg2-binary
 alembic
 pydantic-settings
+python-multipart


### PR DESCRIPTION
## Summary
- include `python-multipart` in backend requirements

## Testing
- `docker build -t proiect-cagri-backend-test .` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849e242d470832c8bc1b5507b018fc2