### PR TITLE
Fix Alembic revision numbering

### DIFF
--- a/backend/migrations/versions/0006_add_is_confirmed_to_attachments.py
+++ b/backend/migrations/versions/0006_add_is_confirmed_to_attachments.py
@@ -1,14 +1,14 @@
 """add is_confirmed column to attachments
 
-Revision ID: 0005
-Revises: 0004
+Revision ID: 0006
+Revises: 0005
 Create Date: 2025-06-11 00:04:00
 """
 from alembic import op
 import sqlalchemy as sa
 
-revision = '0005'
-down_revision = '0004'
+revision = '0006'
+down_revision = '0005'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- rename migration for attachments to `0006`
- update the revision and down_revision numbers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849e245caa4832c9361ea8f62c11e88