### PR TITLE
Add attachments retrieval endpoint

### DIFF
--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -86,3 +86,16 @@ def confirm_application_files(
     confirm_attachments(db, application.id)
     return {"detail": "Attachments confirmed"}
 
+
+@router.get("/{call_id}/attachments", response_model=list[AttachmentOut])
+def list_application_attachments(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return attachments for the current user's application to the given call."""
+    application = get_application_by_user_and_call(db, current_user.id, call_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return get_attachments_by_application(db, application.id)
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -124,12 +124,12 @@ export interface Attachment {
   file_path: string;
 }
 
-export async function fetchApplicationDocuments(callId: number): Promise<Attachment[]> {
+export async function fetchAttachments(callId: number): Promise<Attachment[]> {
   const res = await fetch(`${API_BASE}/applications/${callId}/attachments`, {
     headers: { ...authHeaders() },
   });
   if (!res.ok) {
-    throw new Error('Failed to fetch documents');
+    throw new Error('Failed to fetch attachments');
   }
   return res.json();
 }

--- a/frontend/src/pages/ApplicationPreview.tsx
+++ b/frontend/src/pages/ApplicationPreview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import {
-  fetchApplicationDocuments,
+  fetchAttachments,
   confirmDocuments,
   type Attachment,
 } from '../api';
@@ -14,7 +14,7 @@ export default function ApplicationPreview() {
 
   useEffect(() => {
     if (!callId) return;
-    fetchApplicationDocuments(Number(callId))
+    fetchAttachments(Number(callId))
       .then(setDocs)
       .catch(() => showToast('Failed to load documents', 'error'));
   }, [callId, showToast]);


### PR DESCRIPTION
## Summary
- fetch application attachments in backend
- expose attachments endpoint in frontend API
- use new API in ApplicationPreview page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849e248640c832ca539f5f7240fe612