### PR TITLE
Fix document upload endpoint

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -89,12 +89,13 @@ export async function fetchCalls(onlyOpen = false): Promise<Call[]> {
 }
 
 export async function uploadDocuments(
+  callId: number,
   files: File[],
   onProgress?: (percent: number) => void,
 ) {
   return new Promise<void>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open('POST', `${API_BASE}/documents/upload`);
+    xhr.open('POST', `${API_BASE}/applications/${callId}/upload`);
     const token = getToken();
     if (token) {
       xhr.setRequestHeader('Authorization', `Bearer ${token}`);

--- a/frontend/src/components/DocumentUploadForm.tsx
+++ b/frontend/src/components/DocumentUploadForm.tsx
@@ -18,7 +18,11 @@ interface FormValues {
   documents: FileList
 }
 
-export default function DocumentUploadForm() {
+interface Props {
+  callId: number
+}
+
+export default function DocumentUploadForm({ callId }: Props) {
   const {
     register,
     handleSubmit,
@@ -33,7 +37,7 @@ export default function DocumentUploadForm() {
   const onSubmit = handleSubmit(async ({ documents }) => {
     const files = Array.from(documents)
     try {
-      await uploadDocuments(files, setProgress)
+      await uploadDocuments(callId, files, setProgress)
       showToast('Files uploaded successfully', 'success')
       reset()
     } catch {


### PR DESCRIPTION
## Summary
- point uploadDocuments to /applications/{callId}/upload
- allow DocumentUploadForm to pass callId to the API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849e24aa27c832c840f2327b0cf9fc8