### PR TITLE
Implement call update and delete endpoints

### DIFF
--- a/backend/app/crud/call.py
+++ b/backend/app/crud/call.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from ..models.call import Call
-from ..schemas.call import CallCreate
+from ..schemas.call import CallCreate, CallUpdate
 
 
 def create_call(db: Session, call_in: CallCreate) -> Call:
@@ -14,3 +14,21 @@ def create_call(db: Session, call_in: CallCreate) -> Call:
 
 def get_call(db: Session, call_id: int) -> Call | None:
     return db.query(Call).filter(Call.id == call_id).first()
+
+
+def update_call(db: Session, call: Call, call_in: CallUpdate) -> Call:
+    if call_in.title is not None:
+        call.title = call_in.title
+    if call_in.description is not None:
+        call.description = call_in.description
+    if call_in.is_open is not None:
+        call.is_open = call_in.is_open
+    db.add(call)
+    db.commit()
+    db.refresh(call)
+    return call
+
+
+def delete_call(db: Session, call: Call) -> None:
+    db.delete(call)
+    db.commit()

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
@@ -6,8 +6,8 @@ from ..dependencies import get_current_admin
 from ..models.user import User
 
 from ..models.call import Call
-from ..schemas.call import CallCreate, CallOut
-from ..crud.call import create_call, get_call
+from ..schemas.call import CallCreate, CallOut, CallUpdate
+from ..crud.call import create_call, get_call, update_call, delete_call
 
 router = APIRouter(prefix="/calls", tags=["calls"])
 
@@ -37,3 +37,30 @@ def read_call(call_id: int, db: Session = Depends(get_db)):
     if not call:
         raise HTTPException(status_code=404, detail="Call not found")
     return call
+
+
+@router.put("/{call_id}", response_model=CallOut)
+def update_existing_call(
+    call_id: int,
+    call_in: CallUpdate,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin),
+):
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
+    updated = update_call(db, call, call_in)
+    return updated
+
+
+@router.delete("/{call_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_existing_call(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin),
+):
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
+    delete_call(db, call)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/call.py
+++ b/backend/app/schemas/call.py
@@ -7,6 +7,12 @@ class CallCreate(BaseModel):
     is_open: bool | None = True
 
 
+class CallUpdate(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    is_open: bool | None = None
+
+
 class CallOut(BaseModel):
     id: int
     title: str


### PR DESCRIPTION
## Summary
- implement `CallUpdate` schema
- add CRUD operations for updating and deleting calls
- expose PUT and DELETE endpoints for calls, protected by admin role

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849e577792c832c8bb1ff93fdf1d3ff