### PR TITLE
Implement role-based frontend access control

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import Navbar from './components/Navbar'
 import { ToastProvider } from './components/ToastProvider'
+import { AuthProvider } from './components/AuthProvider'
+import PrivateRoute from './components/PrivateRoute'
 import RegisterPage from './pages/RegisterPage'
 import LoginPage from './pages/LoginPage'
 import CallsPage from './pages/CallsPage'
@@ -14,20 +16,43 @@ import { Routes, Route } from 'react-router-dom'
 function App() {
   return (
     <ToastProvider>
-      <div className="flex flex-col min-h-screen">
-        <Navbar />
-        <main className="max-w-md mx-auto p-4 space-y-8 flex-grow">
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/about" element={<AboutPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/calls" element={<CallsPage />} />
-            <Route path="/admin/calls" element={<CallManagementPage />} />
-            <Route path="/applications/:callId/preview" element={<ApplicationPreview />} />
-          </Routes>
-        </main>
-      </div>
+      <AuthProvider>
+        <div className="flex flex-col min-h-screen">
+          <Navbar />
+          <main className="max-w-md mx-auto p-4 space-y-8 flex-grow">
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/about" element={<AboutPage />} />
+              <Route path="/register" element={<RegisterPage />} />
+              <Route path="/login" element={<LoginPage />} />
+              <Route
+                path="/calls"
+                element={
+                  <PrivateRoute>
+                    <CallsPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/admin/calls"
+                element={
+                  <PrivateRoute roles={['admin']}>
+                    <CallManagementPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/applications/:callId/preview"
+                element={
+                  <PrivateRoute>
+                    <ApplicationPreview />
+                  </PrivateRoute>
+                }
+              />
+            </Routes>
+          </main>
+        </div>
+      </AuthProvider>
     </ToastProvider>
   );
 }

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { getToken, logout as apiLogout, storeToken } from '../api';
+import type { Role } from './RoleSlider';
+
+interface AuthContextType {
+  token: string | null;
+  role: Role | null;
+  login: (token: string, role: Role) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [role, setRole] = useState<Role | null>(null);
+
+  useEffect(() => {
+    const t = getToken();
+    const r = localStorage.getItem('role') as Role | null;
+    if (t) setToken(t);
+    if (r) setRole(r);
+  }, []);
+
+  const login = (tok: string, r: Role) => {
+    storeToken(tok);
+    localStorage.setItem('role', r);
+    setToken(tok);
+    setRole(r);
+  };
+
+  const logout = () => {
+    apiLogout();
+    localStorage.removeItem('role');
+    setToken(null);
+    setRole(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, role, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -2,11 +2,12 @@ import { useForm } from 'react-hook-form'
 import { useState } from 'react'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { login, storeToken } from '../api'
+import { login as apiLogin } from '../api'
 import type { LoginData } from '../api'
 import { useToast } from './ToastProvider'
 import RoleSlider from './RoleSlider'
 import type { Role } from './RoleSlider'
+import { useAuth } from './AuthProvider'
 
 
 const schema = z.object({
@@ -22,10 +23,11 @@ function LoginForm() {
   } = useForm<Omit<LoginData, 'role'>>({ resolver: zodResolver(schema) })
   const { showToast } = useToast()
   const [role, setRole] = useState<Role>('applicant')
+  const { login } = useAuth()
 
   const onSubmit = handleSubmit(async (data) => {
-    const res = await login({ ...data, role })
-    storeToken(res.access_token)
+    const res = await apiLogin({ ...data, role })
+    login(res.access_token, role)
     showToast('Logged in!', 'success')
   })
 

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { useAuth } from './AuthProvider'
 
 function Navbar() {
+  const { token, role, logout } = useAuth()
   return (
     <nav className="bg-gray-800 text-white">
       <div className="mx-[5%] grid grid-cols-1 gap-4 py-3 sm:grid-cols-3 items-center">
@@ -12,12 +14,33 @@ function Navbar() {
         </div>
         <div className="flex justify-center space-x-12 flex-1">
           <Link to="/" className="hover:underline">Home</Link>
-          <Link to="/calls" className="hover:underline">Calls</Link>
+          {token && (
+            <Link to="/calls" className="hover:underline">
+              Calls
+            </Link>
+          )}
           <Link to="/about" className="hover:underline">About</Link>
+          {token && role === 'admin' && (
+            <Link to="/admin/calls" className="hover:underline">
+              Manage Calls
+            </Link>
+          )}
         </div>
         <div className="flex justify-center sm:justify-end space-x-6 flex-1">
-          <Link to="/login" className="bg-blue-500 px-3 py-1 rounded">Login</Link>
-          <Link to="/register" className="bg-green-500 px-3 py-1 rounded">Sign Up</Link>
+          {token ? (
+            <button onClick={logout} className="bg-blue-500 px-3 py-1 rounded">
+              Logout
+            </button>
+          ) : (
+            <>
+              <Link to="/login" className="bg-blue-500 px-3 py-1 rounded">
+                Login
+              </Link>
+              <Link to="/register" className="bg-green-500 px-3 py-1 rounded">
+                Sign Up
+              </Link>
+            </>
+          )}
         </div>
       </div>
     </nav>

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,0 +1,17 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './AuthProvider';
+import type { Role } from './RoleSlider';
+
+interface Props {
+  children: JSX.Element;
+  roles?: Role[];
+}
+
+export default function PrivateRoute({ children, roles }: Props) {
+  const { token, role } = useAuth();
+  if (!token) return <Navigate to="/login" replace />;
+  if (roles && (!role || !roles.includes(role))) {
+    return <Navigate to="/" replace />;
+  }
+  return children;
+}


### PR DESCRIPTION
## Summary
- add AuthProvider and PrivateRoute components to manage authentication state
- adapt LoginForm to use AuthProvider
- update Navbar to show links based on auth role and provide logout
- protect routes with PrivateRoute in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849eadbe2d4832caf56a6b67286f755