### PR TITLE
Implement PDF export for call applications

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -34,3 +34,8 @@ def confirm_documents(db: Session, application: Application) -> Application:
     db.commit()
     db.refresh(application)
     return application
+
+
+def get_applications_by_call(db: Session, call_id: int) -> list[Application]:
+    """Return all applications submitted for the given call."""
+    return db.query(Application).filter(Application.call_id == call_id).all()

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -1,4 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import Response as FastAPIResponse
+from fastapi.templating import Jinja2Templates
+import pdfkit
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
@@ -8,8 +11,12 @@ from ..models.user import User
 from ..models.call import Call
 from ..schemas.call import CallCreate, CallOut, CallUpdate
 from ..crud.call import create_call, get_call, update_call, delete_call
+from ..crud.application import get_applications_by_call
+from ..crud.attachment import get_attachments_by_application
 
 router = APIRouter(prefix="/calls", tags=["calls"])
+
+templates = Jinja2Templates(directory="app/templates")
 
 
 @router.post("/", response_model=CallOut)
@@ -64,3 +71,35 @@ def delete_existing_call(
         raise HTTPException(status_code=404, detail="Call not found")
     delete_call(db, call)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/{call_id}/export-applications.pdf")
+def export_applications_pdf(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin),
+):
+    """Export all applications for a call as a merged PDF document."""
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
+
+    applications = get_applications_by_call(db, call_id)
+    attachments_map = {
+        app.id: get_attachments_by_application(db, app.id) for app in applications
+    }
+
+    html = templates.get_template("applications_export.html").render(
+        {
+            "call": call,
+            "applications": applications,
+            "attachments": attachments_map,
+        }
+    )
+
+    pdf = pdfkit.from_string(html, False)
+
+    headers = {
+        "Content-Disposition": f"attachment; filename=call_{call_id}_applications.pdf"
+    }
+    return FastAPIResponse(content=pdf, media_type="application/pdf", headers=headers)

--- a/backend/app/templates/applications_export.html
+++ b/backend/app/templates/applications_export.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <style>
+        body { font-family: Arial, sans-serif; font-size: 12px; }
+        h1 { font-size: 20px; }
+        h2 { font-size: 16px; margin-top: 20px; }
+        .application { margin-bottom: 30px; }
+    </style>
+</head>
+<body>
+    <h1>{{ call.title }} - Applications</h1>
+    {% for app in applications %}
+    <div class="application">
+        <h2>Application #{{ app.id }} by User {{ app.user_id }}</h2>
+        <p>{{ app.content }}</p>
+        {% set app_attachments = attachments.get(app.id, []) %}
+        {% if app_attachments %}
+        <strong>Attachments:</strong>
+        <ul>
+            {% for att in app_attachments %}
+            <li>{{ att.file_path }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+    {% endfor %}
+</body>
+</html>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,5 @@ psycopg2-binary
 alembic
 pydantic-settings
 python-multipart
+pdfkit
+jinja2


### PR DESCRIPTION
## Summary
- add helper to fetch applications for a call
- expose `/calls/{call_id}/export-applications.pdf` endpoint
- render applications with Jinja2 and convert using pdfkit
- add template for export
- include pdfkit and jinja2 dependencies

## Testing
- `python -m compileall backend/app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f65219dc832c826151c53ba74791