### PR TITLE
Implement basic document workflow

### DIFF
--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,0 +1,5 @@
+from .user import *  # noqa
+from .call import *  # noqa
+from .application import *  # noqa
+from .attachment import *  # noqa
+from .document import *  # noqa

--- a/backend/app/crud/attachment.py
+++ b/backend/app/crud/attachment.py
@@ -3,8 +3,8 @@ from sqlalchemy.orm import Session
 from ..models.attachment import Attachment
 
 
-def create_attachment(db: Session, application_id: int, file_path: str) -> Attachment:
-    attachment = Attachment(application_id=application_id, file_path=file_path)
+def create_attachment(db: Session, application_id: int, file_path: str, document_id: int | None = None) -> Attachment:
+    attachment = Attachment(application_id=application_id, file_path=file_path, document_id=document_id)
     db.add(attachment)
     db.commit()
     db.refresh(attachment)
@@ -19,6 +19,11 @@ def confirm_attachments(db: Session, application_id: int) -> None:
     db.query(Attachment).filter(Attachment.application_id == application_id).update(
         {Attachment.is_confirmed: True}
     )
+    db.commit()
+
+
+def confirm_attachment(db: Session, attachment_id: int) -> None:
+    db.query(Attachment).filter(Attachment.id == attachment_id).update({Attachment.is_confirmed: True})
     db.commit()
 
 

--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -1,0 +1,15 @@
+from sqlalchemy.orm import Session
+
+from ..models.document import DocumentDefinition
+
+
+def create_document_definition(db: Session, call_id: int, name: str, allowed_formats: str) -> DocumentDefinition:
+    doc = DocumentDefinition(call_id=call_id, name=name, allowed_formats=allowed_formats)
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    return doc
+
+
+def list_document_definitions(db: Session, call_id: int) -> list[DocumentDefinition]:
+    return db.query(DocumentDefinition).filter(DocumentDefinition.call_id == call_id).all()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 
 from .routes import users
-from .routes import calls, applications
+from .routes import calls, applications, documents
 from .config import settings
 from .database import Base, engine
 
@@ -32,5 +32,6 @@ app.include_router(users.router)
 app.include_router(users.auth_router)
 app.include_router(calls.router)
 app.include_router(applications.router)
+app.include_router(documents.router)
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,10 +5,12 @@ from .user import User  # noqa: F401
 from .call import Call  # noqa: F401
 from .application import Application  # noqa: F401
 from .attachment import Attachment  # noqa: F401
+from .document import DocumentDefinition  # noqa: F401
 
 __all__ = [
     "User",
     "Call",
     "Application",
     "Attachment",
+    "DocumentDefinition",
 ]

--- a/backend/app/models/attachment.py
+++ b/backend/app/models/attachment.py
@@ -8,5 +8,6 @@ class Attachment(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     application_id = Column(Integer, ForeignKey("applications.id"), nullable=False)
+    document_id = Column(Integer, ForeignKey("document_definitions.id"), nullable=True)
     file_path = Column(String, nullable=False)
     is_confirmed = Column(Boolean, default=False)

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+
+from ..database import Base
+
+
+class DocumentDefinition(Base):
+    __tablename__ = "document_definitions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    call_id = Column(Integer, ForeignKey("calls.id"), nullable=False)
+    name = Column(String, nullable=False)
+    allowed_formats = Column(String, nullable=False)

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from ..dependencies import get_current_admin, get_current_user
+from ..schemas.document import DocumentDefinitionCreate, DocumentDefinitionOut
+from ..crud.document import create_document_definition, list_document_definitions
+
+router = APIRouter(tags=["documents"])
+
+
+@router.post("/admin/calls/{call_id}/documents", response_model=list[DocumentDefinitionOut])
+def create_definition(
+    call_id: int,
+    doc_in: DocumentDefinitionCreate,
+    db: Session = Depends(get_db),
+    current_admin=Depends(get_current_admin),
+):
+    create_document_definition(db, call_id, doc_in.name, doc_in.allowed_formats)
+    return list_document_definitions(db, call_id)
+
+
+@router.get("/applications/{call_id}/documents", response_model=list[DocumentDefinitionOut])
+def get_definitions(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    return list_document_definitions(db, call_id)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,5 @@
+from .user import *  # noqa
+from .call import *  # noqa
+from .application import *  # noqa
+from .attachment import *  # noqa
+from .document import *  # noqa

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class DocumentDefinitionCreate(BaseModel):
+    name: str
+    allowed_formats: str
+
+
+class DocumentDefinitionOut(BaseModel):
+    id: int
+    call_id: int
+    name: str
+    allowed_formats: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/migrations/versions/0007_add_document_definitions.py
+++ b/backend/migrations/versions/0007_add_document_definitions.py
@@ -1,0 +1,34 @@
+"""add document definitions table and document_id to attachments
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2025-06-11 00:05:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0007'
+down_revision = '0006'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'document_definitions',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('call_id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('allowed_formats', sa.String(), nullable=False),
+    )
+    op.create_index('ix_document_definitions_id', 'document_definitions', ['id'])
+    op.add_column('attachments', sa.Column('document_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('fk_attachments_document_id', 'attachments', 'document_definitions', ['document_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('fk_attachments_document_id', 'attachments', type_='foreignkey')
+    op.drop_column('attachments', 'document_id')
+    op.drop_index('ix_document_definitions_id', table_name='document_definitions')
+    op.drop_table('document_definitions')

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import AboutPage from './pages/AboutPage'
 import ApplicationPreview from './pages/ApplicationPreview'
 import CallManagementPage from './pages/CallManagementPage'
 import CallApplicationsPage from './pages/CallApplicationsPage'
+import CallDocumentsPage from './pages/CallDocumentsPage'
+import ApplicationDocumentsPage from './pages/ApplicationDocumentsPage'
 import { Routes, Route } from 'react-router-dom'
 
 
@@ -51,10 +53,26 @@ function App() {
                 }
               />
               <Route
+                path="/admin/calls/:callId/documents"
+                element={
+                  <PrivateRoute roles={['admin']}>
+                    <CallDocumentsPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
                 path="/applications/:callId/preview"
                 element={
                   <PrivateRoute>
                     <ApplicationPreview />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/applications/:callId/documents"
+                element={
+                  <PrivateRoute>
+                    <ApplicationDocumentsPage />
                   </PrivateRoute>
                 }
               />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -130,12 +130,13 @@ export async function deleteCall(id: number): Promise<void> {
 
 export async function uploadDocuments(
   callId: number,
+  documentId: number,
   files: File[],
   onProgress?: (percent: number) => void,
 ) {
   return new Promise<void>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open('POST', `${API_BASE}/applications/${callId}/upload`);
+    xhr.open('POST', `${API_BASE}/applications/${callId}/upload?document_id=${documentId}`);
     const token = getToken();
     if (token) {
       xhr.setRequestHeader('Authorization', `Bearer ${token}`);
@@ -194,6 +195,33 @@ export async function confirmDocuments(callId: number) {
     throw new Error('Failed to confirm documents');
   }
   return res.json();
+}
+
+export interface DocumentDefinition {
+  id: number
+  call_id: number
+  name: string
+  allowed_formats: string
+}
+
+export async function createDocumentDefinition(callId: number, data: { name: string; allowed_formats: string }): Promise<DocumentDefinition[]> {
+  const res = await fetch(`${API_BASE}/admin/calls/${callId}/documents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to save document definition')
+  }
+  return res.json()
+}
+
+export async function fetchDocumentDefinitions(callId: number): Promise<DocumentDefinition[]> {
+  const res = await fetch(`${API_BASE}/applications/${callId}/documents`, { headers: { ...authHeaders() } })
+  if (!res.ok) {
+    throw new Error('Failed to load document definitions')
+  }
+  return res.json()
 }
 
 export async function fetchApplications(

--- a/frontend/src/components/DocumentSlider.tsx
+++ b/frontend/src/components/DocumentSlider.tsx
@@ -1,0 +1,23 @@
+import { DocumentDefinition } from '../api'
+
+interface Props {
+  documents: DocumentDefinition[]
+  selected: number | null
+  onSelect: (id: number) => void
+}
+
+export default function DocumentSlider({ documents, selected, onSelect }: Props) {
+  return (
+    <ul className="space-y-2 border-r pr-2">
+      {documents.map((d) => (
+        <li
+          key={d.id}
+          className={`cursor-pointer p-2 rounded ${selected === d.id ? 'bg-blue-500 text-white' : 'bg-gray-100'}`}
+          onClick={() => onSelect(d.id)}
+        >
+          {d.name}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/components/DocumentUploadForm.tsx
+++ b/frontend/src/components/DocumentUploadForm.tsx
@@ -20,9 +20,10 @@ interface FormValues {
 
 interface Props {
   callId: number
+  documentId: number
 }
 
-export default function DocumentUploadForm({ callId }: Props) {
+export default function DocumentUploadForm({ callId, documentId }: Props) {
   const {
     register,
     handleSubmit,
@@ -37,7 +38,7 @@ export default function DocumentUploadForm({ callId }: Props) {
   const onSubmit = handleSubmit(async ({ documents }) => {
     const files = Array.from(documents)
     try {
-      await uploadDocuments(callId, files, setProgress)
+      await uploadDocuments(callId, documentId, files, setProgress)
       showToast('Files uploaded successfully', 'success')
       reset()
     } catch {

--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  value: number
+}
+
+export default function ProgressBar({ value }: Props) {
+  return (
+    <div className="w-full bg-gray-200 h-2 rounded">
+      <div className="bg-blue-500 h-2 rounded" style={{ width: `${value}%` }} />
+    </div>
+  )
+}

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { uploadDocuments } from '../api'
+import ProgressBar from './ProgressBar'
+import { useToast } from './ToastProvider'
+
+interface Props {
+  callId: number
+  documentId: number
+  description: string
+}
+
+const schema = z.object({
+  file: z.any().refine((f) => f instanceof FileList && f.length === 1, 'Select a file'),
+})
+
+type FormValues = {
+  file: FileList
+}
+
+export default function UploadPanel({ callId, documentId, description }: Props) {
+  const [progress, setProgress] = useState(0)
+  const { showToast } = useToast()
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  const onSubmit = handleSubmit(async ({ file }) => {
+    try {
+      await uploadDocuments(callId, documentId, [file[0]], setProgress)
+      showToast('Uploaded', 'success')
+      reset()
+    } catch {
+      showToast('Upload failed', 'error')
+    } finally {
+      setProgress(0)
+    }
+  })
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <p>{description}</p>
+      <input type="file" {...register('file')} />
+      {errors.file && <p className="text-red-600">{errors.file.message}</p>}
+      {progress > 0 && <ProgressBar value={progress} />}
+      <button className="bg-blue-600 text-white px-4 py-1 rounded" type="submit">
+        Upload
+      </button>
+    </form>
+  )
+}

--- a/frontend/src/pages/ApplicationDocumentsPage.tsx
+++ b/frontend/src/pages/ApplicationDocumentsPage.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import DocumentSlider from '../components/DocumentSlider'
+import UploadPanel from '../components/UploadPanel'
+import { fetchDocumentDefinitions, DocumentDefinition } from '../api'
+import { useToast } from '../components/ToastProvider'
+
+export default function ApplicationDocumentsPage() {
+  const { callId } = useParams()
+  const [docs, setDocs] = useState<DocumentDefinition[]>([])
+  const [selected, setSelected] = useState<number | null>(null)
+  const { showToast } = useToast()
+
+  useEffect(() => {
+    if (!callId) return
+    fetchDocumentDefinitions(Number(callId))
+      .then((d) => {
+        setDocs(d)
+        if (d.length > 0) setSelected(d[0].id)
+      })
+      .catch(() => showToast('Failed to load documents', 'error'))
+  }, [callId, showToast])
+
+  if (!callId) return <p>No call selected</p>
+
+  const current = docs.find((d) => d.id === selected)
+
+  return (
+    <div className="flex space-x-4">
+      <DocumentSlider documents={docs} selected={selected} onSelect={setSelected} />
+      {current && (
+        <div className="flex-1">
+          <UploadPanel callId={Number(callId)} documentId={current.id} description={`Upload ${current.name}`} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/CallDocumentsPage.tsx
+++ b/frontend/src/pages/CallDocumentsPage.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { createDocumentDefinition, DocumentDefinition } from '../api'
+import { useToast } from '../components/ToastProvider'
+
+const schema = z.object({
+  name: z.string().min(1),
+  allowed_formats: z.string().min(1),
+})
+
+type FormValues = z.infer<typeof schema>
+
+export default function CallDocumentsPage() {
+  const { callId } = useParams()
+  const [docs, setDocs] = useState<DocumentDefinition[]>([])
+  const { showToast } = useToast()
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  if (!callId) return <p>No call selected.</p>
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      const updated = await createDocumentDefinition(Number(callId), data)
+      setDocs(updated)
+      showToast('Saved', 'success')
+      reset()
+    } catch {
+      showToast('Failed', 'error')
+    }
+  })
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-xl font-bold">Required Documents</h1>
+      <form onSubmit={onSubmit} className="space-y-2">
+        <input placeholder="Name" className="border p-1 w-full" {...register('name')} />
+        {errors.name && <p className="text-red-600">{errors.name.message}</p>}
+        <select className="border p-1 w-full" {...register('allowed_formats')}>
+          <option value="pdf">PDF</option>
+          <option value="image">Image</option>
+          <option value="text">Text</option>
+        </select>
+        <button className="bg-blue-600 text-white px-3 py-1 rounded" type="submit">Save</button>
+      </form>
+      {docs.length > 0 && (
+        <ul className="list-disc pl-5">
+          {docs.map((d) => (
+            <li key={d.id}>{d.name} - {d.allowed_formats}</li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add document model and migrations
- allow admin to create document definitions for calls
- expose endpoints for listing document definitions
- extend attachments to link to a document
- create minimal upload slider and panel components
- add pages for document setup and uploading
- update routes and API helpers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849f8b2e0bc832cb96f70caf2741ddc