### PR TITLE
Fix DocumentDefinition import types

### DIFF
--- a/frontend/src/components/DocumentSlider.tsx
+++ b/frontend/src/components/DocumentSlider.tsx
@@ -1,4 +1,4 @@
-import { DocumentDefinition } from '../api'
+import type { DocumentDefinition } from '../api'
 
 interface Props {
   documents: DocumentDefinition[]

--- a/frontend/src/pages/ApplicationDocumentsPage.tsx
+++ b/frontend/src/pages/ApplicationDocumentsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import DocumentSlider from '../components/DocumentSlider'
 import UploadPanel from '../components/UploadPanel'
-import { fetchDocumentDefinitions, DocumentDefinition } from '../api'
+import { fetchDocumentDefinitions, type DocumentDefinition } from '../api'
 import { useToast } from '../components/ToastProvider'
 
 export default function ApplicationDocumentsPage() {

--- a/frontend/src/pages/CallDocumentsPage.tsx
+++ b/frontend/src/pages/CallDocumentsPage.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { createDocumentDefinition, DocumentDefinition } from '../api'
+import { createDocumentDefinition, type DocumentDefinition } from '../api'
 import { useToast } from '../components/ToastProvider'
 
 const schema = z.object({


### PR DESCRIPTION
## Summary
- mark `DocumentDefinition` as a type-only import so Vite doesn't expect a runtime export

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849fb5718f4832c9491e810c27d901d