### PR TITLE
Add migrations to API Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,5 +2,10 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Include migrations so Alembic can run inside the container
+COPY alembic.ini ./
+COPY migrations ./migrations
+
 COPY app ./app
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,6 +29,10 @@ When using Docker you can run the command inside the API container:
 docker-compose run --rm api alembic upgrade head
 ```
 
+The Docker image now bundles the `migrations/` directory and `alembic.ini`, so
+you can execute Alembic commands directly in the container. Rebuild the image
+whenever new migrations are added.
+
 ### Authentication
 
 Send a POST request to `/login` with `email` and `password`. After entering


### PR DESCRIPTION
## Summary
- include Alembic files in the backend Docker image
- document how to run migrations inside the container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849fc9990c4832ca75387d31ffafd8f