### PR TITLE
Implement call management improvements

### DIFF
--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -3,12 +3,43 @@ from sqlalchemy.orm import Session
 from ..models.document import DocumentDefinition
 
 
-def create_document_definition(db: Session, call_id: int, name: str, allowed_formats: str) -> DocumentDefinition:
-    doc = DocumentDefinition(call_id=call_id, name=name, allowed_formats=allowed_formats)
+def create_document_definition(
+    db: Session, call_id: int, name: str, allowed_formats: str, description: str | None = None
+) -> DocumentDefinition:
+    doc = DocumentDefinition(
+        call_id=call_id,
+        name=name,
+        allowed_formats=allowed_formats,
+        description=description,
+    )
     db.add(doc)
     db.commit()
     db.refresh(doc)
     return doc
+
+
+def update_document_definition(
+    db: Session,
+    doc: DocumentDefinition,
+    name: str | None = None,
+    allowed_formats: str | None = None,
+    description: str | None = None,
+) -> DocumentDefinition:
+    if name is not None:
+        doc.name = name
+    if allowed_formats is not None:
+        doc.allowed_formats = allowed_formats
+    if description is not None:
+        doc.description = description
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    return doc
+
+
+def delete_document_definition(db: Session, doc: DocumentDefinition) -> None:
+    db.delete(doc)
+    db.commit()
 
 
 def list_document_definitions(db: Session, call_id: int) -> list[DocumentDefinition]:

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -9,4 +9,5 @@ class DocumentDefinition(Base):
     id = Column(Integer, primary_key=True, index=True)
     call_id = Column(Integer, ForeignKey("calls.id"), nullable=False)
     name = Column(String, nullable=False)
+    description = Column(String)
     allowed_formats = Column(String, nullable=False)

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -1,10 +1,20 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
 from ..dependencies import get_current_admin, get_current_user
-from ..schemas.document import DocumentDefinitionCreate, DocumentDefinitionOut
-from ..crud.document import create_document_definition, list_document_definitions
+from ..schemas.document import (
+    DocumentDefinitionCreate,
+    DocumentDefinitionOut,
+    DocumentDefinitionUpdate,
+)
+from ..crud.document import (
+    create_document_definition,
+    list_document_definitions,
+    update_document_definition,
+    delete_document_definition,
+)
+from ..models.document import DocumentDefinition
 
 router = APIRouter(tags=["documents"])
 
@@ -16,8 +26,56 @@ def create_definition(
     db: Session = Depends(get_db),
     current_admin=Depends(get_current_admin),
 ):
-    create_document_definition(db, call_id, doc_in.name, doc_in.allowed_formats)
+    create_document_definition(
+        db, call_id, doc_in.name, doc_in.allowed_formats, doc_in.description
+    )
     return list_document_definitions(db, call_id)
+
+
+@router.put(
+    "/admin/calls/{call_id}/documents/{doc_id}",
+    response_model=DocumentDefinitionOut,
+)
+def update_definition(
+    call_id: int,
+    doc_id: int,
+    doc_in: DocumentDefinitionUpdate,
+    db: Session = Depends(get_db),
+    current_admin=Depends(get_current_admin),
+):
+    doc = (
+        db.query(DocumentDefinition)
+        .filter(DocumentDefinition.id == doc_id, DocumentDefinition.call_id == call_id)
+        .first()
+    )
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    updated = update_document_definition(
+        db,
+        doc,
+        name=doc_in.name,
+        allowed_formats=doc_in.allowed_formats,
+        description=doc_in.description,
+    )
+    return updated
+
+
+@router.delete("/admin/calls/{call_id}/documents/{doc_id}", status_code=204)
+def delete_definition(
+    call_id: int,
+    doc_id: int,
+    db: Session = Depends(get_db),
+    current_admin=Depends(get_current_admin),
+):
+    doc = (
+        db.query(DocumentDefinition)
+        .filter(DocumentDefinition.id == doc_id, DocumentDefinition.call_id == call_id)
+        .first()
+    )
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    delete_document_definition(db, doc)
+    return Response(status_code=204)
 
 
 @router.get("/applications/{call_id}/documents", response_model=list[DocumentDefinitionOut])

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -3,13 +3,21 @@ from pydantic import BaseModel, ConfigDict
 
 class DocumentDefinitionCreate(BaseModel):
     name: str
+    description: str | None = None
     allowed_formats: str
+
+
+class DocumentDefinitionUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    allowed_formats: str | None = None
 
 
 class DocumentDefinitionOut(BaseModel):
     id: int
     call_id: int
     name: str
+    description: str | None = None
     allowed_formats: str
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/migrations/versions/0008_add_description_to_document_definitions.py
+++ b/backend/migrations/versions/0008_add_description_to_document_definitions.py
@@ -1,0 +1,22 @@
+"""add description to document definitions
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2025-06-12 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0008'
+down_revision = '0007'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('document_definitions', sa.Column('description', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('document_definitions', 'description')

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "react-router-dom": "^6.23.0",
     "@hookform/resolvers": "^3.3.1",
     "react-hook-form": "^7.50.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@tanstack/react-query": "^5.29.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,9 +8,12 @@ import CallsPage from './pages/CallsPage'
 import HomePage from './pages/HomePage'
 import AboutPage from './pages/AboutPage'
 import ApplicationPreview from './pages/ApplicationPreview'
+import CallDetailPage from './pages/CallDetailPage'
 import CallManagementPage from './pages/CallManagementPage'
 import CallApplicationsPage from './pages/CallApplicationsPage'
 import CallDocumentsPage from './pages/CallDocumentsPage'
+import CreateCallPage from './pages/CreateCallPage'
+import EditCallPage from './pages/EditCallPage'
 import ApplicationDocumentsPage from './pages/ApplicationDocumentsPage'
 import { Routes, Route } from 'react-router-dom'
 
@@ -37,10 +40,34 @@ function App() {
                 }
               />
               <Route
+                path="/calls/:callId"
+                element={
+                  <PrivateRoute>
+                    <CallDetailPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
                 path="/admin/calls"
                 element={
                   <PrivateRoute roles={['admin']}>
                     <CallManagementPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/admin/calls/new"
+                element={
+                  <PrivateRoute roles={['admin']}>
+                    <CreateCallPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/admin/calls/:callId/edit"
+                element={
+                  <PrivateRoute roles={['admin']}>
+                    <EditCallPage />
                   </PrivateRoute>
                 }
               />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -88,6 +88,14 @@ export async function fetchCalls(onlyOpen = false): Promise<Call[]> {
   return res.json();
 }
 
+export async function fetchCall(callId: number): Promise<Call> {
+  const res = await fetch(`${API_BASE}/calls/${callId}`, { headers: { ...authHeaders() } })
+  if (!res.ok) {
+    throw new Error('Failed to fetch call')
+  }
+  return res.json()
+}
+
 export interface CallInput {
   title: string;
   description?: string | null;
@@ -201,10 +209,11 @@ export interface DocumentDefinition {
   id: number
   call_id: number
   name: string
+  description?: string | null
   allowed_formats: string
 }
 
-export async function createDocumentDefinition(callId: number, data: { name: string; allowed_formats: string }): Promise<DocumentDefinition[]> {
+export async function createDocumentDefinition(callId: number, data: { name: string; description?: string | null; allowed_formats: string }): Promise<DocumentDefinition[]> {
   const res = await fetch(`${API_BASE}/admin/calls/${callId}/documents`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -214,6 +223,28 @@ export async function createDocumentDefinition(callId: number, data: { name: str
     throw new Error('Failed to save document definition')
   }
   return res.json()
+}
+
+export async function updateDocumentDefinition(callId: number, docId: number, data: { name: string; description?: string | null; allowed_formats: string }): Promise<DocumentDefinition> {
+  const res = await fetch(`${API_BASE}/admin/calls/${callId}/documents/${docId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to update document definition')
+  }
+  return res.json()
+}
+
+export async function deleteDocumentDefinition(callId: number, docId: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/admin/calls/${callId}/documents/${docId}`, {
+    method: 'DELETE',
+    headers: { ...authHeaders() },
+  })
+  if (!res.ok) {
+    throw new Error('Failed to delete document definition')
+  }
 }
 
 export async function fetchDocumentDefinitions(callId: number): Promise<DocumentDefinition[]> {

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,5 +1,6 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import { getToken, logout as apiLogout, storeToken } from '../api';
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getToken, logout as apiLogout, storeToken } from '../api'
 import type { Role } from './RoleSlider';
 
 interface AuthContextType {
@@ -12,8 +13,9 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [token, setToken] = useState<string | null>(null);
-  const [role, setRole] = useState<Role | null>(null);
+  const navigate = useNavigate()
+  const [token, setToken] = useState<string | null>(null)
+  const [role, setRole] = useState<Role | null>(null)
 
   useEffect(() => {
     const t = getToken();
@@ -21,6 +23,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (t) setToken(t);
     if (r) setRole(r);
   }, []);
+
+  useEffect(() => {
+    if (token && role) {
+      if (role === 'admin') navigate('/admin/calls', { replace: true })
+      else navigate('/calls', { replace: true })
+    }
+  }, [token, role, navigate])
 
   const login = (tok: string, r: Role) => {
     storeToken(tok);

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -15,7 +15,11 @@ const schema = z.object({
   password: z.string().min(1),
 });
 
-function LoginForm() {
+interface Props {
+  onSuccess?: (role: Role) => void
+}
+
+function LoginForm({ onSuccess }: Props) {
   const {
     register,
     handleSubmit,
@@ -29,6 +33,7 @@ function LoginForm() {
     const res = await apiLogin({ ...data, role })
     login(res.access_token, role)
     showToast('Logged in!', 'success')
+    onSuccess?.(role)
   })
 
   return (

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -12,7 +12,11 @@ const schema = z.object({
   role: z.string().min(1),
 });
 
-function RegisterForm() {
+interface Props {
+  onSuccess?: () => void
+}
+
+function RegisterForm({ onSuccess }: Props) {
   const {
     register,
     handleSubmit,
@@ -21,9 +25,10 @@ function RegisterForm() {
   const { showToast } = useToast();
 
   const onSubmit = async (data: RegisterData) => {
-    await registerUser(data);
-    showToast('Registered successfully', 'success');
-  };
+    await registerUser(data)
+    showToast('Registered successfully', 'success')
+    onSuccess?.()
+  }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,18 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
+
+const client = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <QueryClientProvider client={client}>
+        <App />
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/pages/CallDetailPage.tsx
+++ b/frontend/src/pages/CallDetailPage.tsx
@@ -1,0 +1,43 @@
+import { useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { fetchCall, fetchDocumentDefinitions, fetchAttachments } from '../api'
+import ApplicationDocumentsPage from './ApplicationDocumentsPage'
+import ApplicationPreview from './ApplicationPreview'
+
+export default function CallDetailPage() {
+  const { callId } = useParams()
+  const id = Number(callId)
+
+  const callQuery = useQuery({
+    queryKey: ['call', id],
+    queryFn: () => fetchCall(id),
+    enabled: !!callId,
+  })
+
+  useQuery({
+    queryKey: ['docs', id],
+    queryFn: () => fetchDocumentDefinitions(id),
+    enabled: !!callId,
+  })
+
+  const attachmentsQuery = useQuery({
+    queryKey: ['attachments', id],
+    queryFn: () => fetchAttachments(id),
+    enabled: !!callId,
+    retry: false,
+  })
+
+  if (!callId) return <p>No call selected.</p>
+  if (callQuery.isLoading) return <p>Loading...</p>
+  if (callQuery.isError) return <p>Failed to load call.</p>
+
+  const hasApplied = !attachmentsQuery.isError
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-xl font-bold">{callQuery.data?.title}</h1>
+      {callQuery.data?.description && <p>{callQuery.data.description}</p>}
+      {hasApplied ? <ApplicationPreview /> : <ApplicationDocumentsPage />}
+    </section>
+  )
+}

--- a/frontend/src/pages/CallManagementPage.tsx
+++ b/frontend/src/pages/CallManagementPage.tsx
@@ -1,35 +1,19 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { Link, useNavigate } from 'react-router-dom'
 import {
   fetchCalls,
-  createCall,
-  updateCall,
   deleteCall,
   type Call,
-  type CallInput,
 } from '../api'
 import { useToast } from '../components/ToastProvider'
 
-const schema = z.object({
-  title: z.string().min(1),
-  description: z.string().optional(),
-  is_open: z.boolean().optional(),
-})
-
 export default function CallManagementPage() {
   const [calls, setCalls] = useState<Call[]>([])
-  const [editingId, setEditingId] = useState<number | null>(null)
+  const navigate = useNavigate()
+  const [filterText, setFilterText] = useState('')
+  const [sortField, setSortField] = useState<'title' | 'open' | null>(null)
+  const [sortAsc, setSortAsc] = useState(true)
   const { showToast } = useToast()
-
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors, isSubmitting },
-  } = useForm<CallInput>({ resolver: zodResolver(schema) })
 
   const loadCalls = () => {
     fetchCalls()
@@ -41,26 +25,17 @@ export default function CallManagementPage() {
     loadCalls()
   }, [])
 
-  const onSubmit = handleSubmit(async (data) => {
-    try {
-      if (editingId) {
-        await updateCall(editingId, data)
-        showToast('Call updated', 'success')
-      } else {
-        await createCall(data)
-        showToast('Call created', 'success')
-      }
-      setEditingId(null)
-      reset()
-      loadCalls()
-    } catch {
-      showToast('Failed to save call', 'error')
+  const handleSort = (field: 'title' | 'open') => {
+    if (sortField === field) {
+      setSortAsc(!sortAsc)
+    } else {
+      setSortField(field)
+      setSortAsc(true)
     }
-  })
+  }
 
-  const onEdit = (call: Call) => {
-    setEditingId(call.id)
-    reset({ title: call.title, description: call.description, is_open: call.is_open })
+  const onEdit = (id: number) => {
+    navigate(`/admin/calls/${id}/edit`)
   }
 
   const onDelete = async (id: number) => {
@@ -73,20 +48,54 @@ export default function CallManagementPage() {
     }
   }
 
+  const filtered = calls.filter(
+    (c) =>
+      c.title.toLowerCase().includes(filterText.toLowerCase()) ||
+      (c.description || '').toLowerCase().includes(filterText.toLowerCase()),
+  )
+  const sorted = [...filtered]
+  if (sortField === 'title') {
+    sorted.sort((a, b) =>
+      sortAsc ? a.title.localeCompare(b.title) : b.title.localeCompare(a.title),
+    )
+  } else if (sortField === 'open') {
+    sorted.sort((a, b) => {
+      if (a.is_open === b.is_open) return 0
+      const res = a.is_open ? -1 : 1
+      return sortAsc ? res : -res
+    })
+  }
+
   return (
     <section className="space-y-6">
       <h1 className="text-xl font-bold">Call Management</h1>
+      <input
+        value={filterText}
+        onChange={(e) => setFilterText(e.target.value)}
+        placeholder="Filter"
+        className="border p-2 w-full"
+      />
       <table className="min-w-full border">
         <thead>
           <tr className="bg-gray-100">
-            <th className="p-2 text-left">Title</th>
+            <th
+              className="p-2 text-left cursor-pointer"
+              onClick={() => handleSort('title')}
+            >
+              Title
+            </th>
             <th className="p-2 text-left">Description</th>
-            <th className="p-2">Open</th>
+            <th
+              className="p-2 cursor-pointer"
+              onClick={() => handleSort('open')}
+            >
+              Open
+            </th>
             <th className="p-2">Actions</th>
           </tr>
         </thead>
         <tbody>
-          {calls.map((c) => (
+          {sorted.map((c) => (
             <tr key={c.id} className="border-t">
               <td className="p-2">{c.title}</td>
               <td className="p-2">{c.description}</td>
@@ -110,33 +119,9 @@ export default function CallManagementPage() {
         </tbody>
       </table>
 
-      <form onSubmit={onSubmit} className="space-y-4 border p-4 rounded">
-        <h2 className="text-lg font-semibold">
-          {editingId ? 'Edit Call' : 'Create New Call'}
-        </h2>
-        <div>
-          <label className="block">
-            Title
-            <input {...register('title')} className="border p-2 w-full" />
-          </label>
-          {errors.title && <p className="text-red-600">{errors.title.message}</p>}
-        </div>
-        <div>
-          <label className="block">
-            Description
-            <textarea {...register('description')} className="border p-2 w-full" />
-          </label>
-        </div>
-        <div>
-          <label className="inline-flex items-center space-x-2">
-            <input type="checkbox" {...register('is_open')} defaultChecked />
-            <span>Open</span>
-          </label>
-        </div>
-        <button disabled={isSubmitting} className="bg-blue-600 text-white px-4 py-2 rounded">
-          {editingId ? 'Update' : 'Create'}
-        </button>
-      </form>
+      <div>
+        <Link to="/admin/calls/new" className="underline text-blue-600">Create New Call</Link>
+      </div>
     </section>
   )
 }

--- a/frontend/src/pages/CreateCallPage.tsx
+++ b/frontend/src/pages/CreateCallPage.tsx
@@ -1,0 +1,96 @@
+import { useFieldArray, useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useNavigate } from 'react-router-dom'
+import { createCall, createDocumentDefinition } from '../api'
+import { useToast } from '../components/ToastProvider'
+
+const itemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  allowed_format: z.enum(['pdf', 'image', 'text']),
+})
+
+const schema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  is_open: z.boolean().optional(),
+  items: z.array(itemSchema),
+})
+
+type FormValues = z.infer<typeof schema>
+
+export default function CreateCallPage() {
+  const navigate = useNavigate()
+  const { showToast } = useToast()
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema), defaultValues: { items: [] } })
+  const { fields, append, remove } = useFieldArray({ control, name: 'items' })
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      const call = await createCall({ title: data.title, description: data.description, is_open: data.is_open })
+      for (const item of data.items) {
+        await createDocumentDefinition(call.id, {
+          name: item.name,
+          description: item.description,
+          allowed_formats: item.allowed_format,
+        })
+      }
+      showToast('Call created', 'success')
+      navigate('/admin/calls')
+    } catch {
+      showToast('Failed to create call', 'error')
+    }
+  })
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <h1 className="text-xl font-bold">Create Call</h1>
+      <div>
+        <label className="block">
+          Title
+          <input {...register('title')} className="border p-2 w-full" />
+        </label>
+        {errors.title && <p className="text-red-600">{errors.title.message}</p>}
+      </div>
+      <div>
+        <label className="block">
+          Description
+          <textarea {...register('description')} className="border p-2 w-full" />
+        </label>
+      </div>
+      <div>
+        <label className="inline-flex items-center space-x-2">
+          <input type="checkbox" {...register('is_open')} defaultChecked />
+          <span>Open</span>
+        </label>
+      </div>
+      <div>
+        <h2 className="font-semibold">Required Items</h2>
+        {fields.map((field, idx) => (
+          <div key={field.id} className="border p-2 space-y-2 mb-2">
+            <input {...register(`items.${idx}.name` as const)} placeholder="Name" className="border p-1 w-full" />
+            <input {...register(`items.${idx}.description` as const)} placeholder="Description" className="border p-1 w-full" />
+            <select {...register(`items.${idx}.allowed_format` as const)} className="border p-1 w-full">
+              <option value="pdf">PDF</option>
+              <option value="image">Image</option>
+              <option value="text">Text</option>
+            </select>
+            <button type="button" onClick={() => remove(idx)} className="text-red-600 underline">Delete</button>
+          </div>
+        ))}
+        <button type="button" onClick={() => append({ name: '', description: '', allowed_format: 'pdf' })} className="bg-gray-200 px-2 py-1 rounded">
+          Add Item
+        </button>
+      </div>
+      <button disabled={isSubmitting} className="bg-blue-600 text-white px-4 py-2 rounded">
+        Create
+      </button>
+    </form>
+  )
+}

--- a/frontend/src/pages/EditCallPage.tsx
+++ b/frontend/src/pages/EditCallPage.tsx
@@ -1,0 +1,147 @@
+import { useEffect } from 'react'
+import { useFieldArray, useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  fetchCall,
+  fetchDocumentDefinitions,
+  updateCall,
+  createDocumentDefinition,
+  updateDocumentDefinition,
+  deleteDocumentDefinition,
+} from '../api'
+import { useToast } from '../components/ToastProvider'
+
+const itemSchema = z.object({
+  id: z.number().optional(),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  allowed_format: z.enum(['pdf', 'image', 'text']),
+})
+
+const schema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  is_open: z.boolean().optional(),
+  items: z.array(itemSchema),
+})
+
+type FormValues = z.infer<typeof schema>
+
+export default function EditCallPage() {
+  const { callId } = useParams()
+  const id = Number(callId)
+  const navigate = useNavigate()
+  const { showToast } = useToast()
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema), defaultValues: { items: [] } })
+  const { fields, append, remove } = useFieldArray({ control, name: 'items' })
+
+  useEffect(() => {
+    if (!id) return
+    ;(async () => {
+      const c = await fetchCall(id)
+      const docs = await fetchDocumentDefinitions(id)
+      reset({
+        title: c.title,
+        description: c.description || '',
+        is_open: c.is_open,
+        items: docs.map((d) => ({
+          id: d.id,
+          name: d.name,
+          description: d.description || '',
+          allowed_format: d.allowed_formats as 'pdf' | 'image' | 'text',
+        })),
+      })
+    })()
+  }, [id, reset])
+
+  const onDeleteDoc = async (index: number, docId?: number) => {
+    if (docId) {
+      await deleteDocumentDefinition(id, docId)
+    }
+    remove(index)
+  }
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      await updateCall(id, {
+        title: data.title,
+        description: data.description,
+        is_open: data.is_open,
+      })
+      for (const item of data.items) {
+        if (item.id) {
+          await updateDocumentDefinition(id, item.id, {
+            name: item.name,
+            description: item.description,
+            allowed_formats: item.allowed_format,
+          })
+        } else {
+          await createDocumentDefinition(id, {
+            name: item.name,
+            description: item.description,
+            allowed_formats: item.allowed_format,
+          })
+        }
+      }
+      showToast('Call updated', 'success')
+      navigate('/admin/calls')
+    } catch {
+      showToast('Failed to update call', 'error')
+    }
+  })
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <h1 className="text-xl font-bold">Edit Call</h1>
+      <div>
+        <label className="block">
+          Title
+          <input {...register('title')} className="border p-2 w-full" />
+        </label>
+        {errors.title && <p className="text-red-600">{errors.title.message}</p>}
+      </div>
+      <div>
+        <label className="block">
+          Description
+          <textarea {...register('description')} className="border p-2 w-full" />
+        </label>
+      </div>
+      <div>
+        <label className="inline-flex items-center space-x-2">
+          <input type="checkbox" {...register('is_open')} />
+          <span>Open</span>
+        </label>
+      </div>
+      <div>
+        <h2 className="font-semibold">Required Items</h2>
+        {fields.map((field, idx) => (
+          <div key={field.id} className="border p-2 space-y-2 mb-2">
+            <input {...register(`items.${idx}.name` as const)} placeholder="Name" className="border p-1 w-full" />
+            <input {...register(`items.${idx}.description` as const)} placeholder="Description" className="border p-1 w-full" />
+            <select {...register(`items.${idx}.allowed_format` as const)} className="border p-1 w-full">
+              <option value="pdf">PDF</option>
+              <option value="image">Image</option>
+              <option value="text">Text</option>
+            </select>
+            <button type="button" onClick={() => onDeleteDoc(idx, field.id as number | undefined)} className="text-red-600 underline">Delete</button>
+          </div>
+        ))}
+        <button type="button" onClick={() => append({ name: '', description: '', allowed_format: 'pdf' })} className="bg-gray-200 px-2 py-1 rounded">
+          Add Item
+        </button>
+      </div>
+      <button disabled={isSubmitting} className="bg-blue-600 text-white px-4 py-2 rounded">
+        Save
+      </button>
+    </form>
+  )
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,9 +1,11 @@
 import LoginForm from '../components/LoginForm'
+import { useNavigate } from 'react-router-dom'
 
 export default function LoginPage() {
+  const navigate = useNavigate()
   return (
     <div className="mt-8">
-      <LoginForm />
+      <LoginForm onSuccess={(role) => navigate(role === 'admin' ? '/admin/calls' : '/calls')} />
     </div>
   )
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,9 +1,11 @@
 import RegisterForm from '../components/RegisterForm'
+import { useNavigate } from 'react-router-dom'
 
 export default function RegisterPage() {
+  const navigate = useNavigate()
   return (
     <div className="mt-8">
-      <RegisterForm />
+      <RegisterForm onSuccess={() => navigate('/login')} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- redirect to appropriate page after login/registration
- add React Query provider and call detail page
- enable filtering and sorting in call management
- move call creation to its own page
- add edit call page with document definition management
- support document definition CRUD on backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a02718b90832caac406488914b966