### PR TITLE
Improve call management UI with shadcn components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "@hookform/resolvers": "^3.3.1",
     "react-hook-form": "^7.50.1",
     "zod": "^3.22.4",
-    "@tanstack/react-query": "^5.29.0"
+    "@tanstack/react-query": "^5.29.0",
+    "lucide-react": "^0.371.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline' | 'destructive' | 'link'
+  asChild?: boolean
+}
+
+const base = 'inline-flex items-center justify-center font-medium rounded-md text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none'
+const variants: Record<string, string> = {
+  default: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
+  outline: 'border border-gray-300 hover:bg-gray-100 text-gray-900 focus:ring-gray-500',
+  destructive: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+  link: 'text-blue-600 underline-offset-4 hover:underline focus:ring-transparent px-0'
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = '', variant = 'default', asChild, ...props }, ref) => {
+    const Comp: any = asChild ? 'span' : 'button'
+    return (
+      <Comp
+        ref={ref}
+        className={`${base} ${variants[variant]} ${className} px-3 py-2`}
+        {...props}
+      />
+    )
+  },
+)
+Button.displayName = 'Button'

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export function Card({ className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`border rounded-md bg-white shadow-sm ${className}`} {...props} />
+}
+
+export function CardHeader({ className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`border-b px-6 py-4 ${className}`} {...props} />
+}
+
+export function CardContent({ className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`p-6 ${className}`} {...props} />
+}

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className = '', ...props }, ref) => (
+  <input
+    ref={ref}
+    className={`flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 ${className}`}
+    {...props}
+  />
+))
+Input.displayName = 'Input'

--- a/frontend/src/components/ui/Table.tsx
+++ b/frontend/src/components/ui/Table.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+export function Table({ className = '', ...props }: React.HTMLAttributes<HTMLTableElement>) {
+  return <table className={`w-full text-sm ${className}`} {...props} />
+}
+
+export function TableHeader({ className = '', ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={`bg-gray-100 ${className}`} {...props} />
+}
+
+export function TableBody({ className = '', ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={className} {...props} />
+}
+
+export function TableRow({ className = '', ...props }: React.HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={`border-b last:border-0 ${className}`} {...props} />
+}
+
+export function TableHead({ className = '', ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return <th className={`p-2 text-left font-semibold ${className}`} {...props} />
+}
+
+export function TableCell({ className = '', ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={`p-2 ${className}`} {...props} />
+}

--- a/frontend/src/pages/CallManagementPage.tsx
+++ b/frontend/src/pages/CallManagementPage.tsx
@@ -1,5 +1,17 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { Search as SearchIcon, Pencil, Trash2, Eye } from 'lucide-react'
+import { Input } from '../components/ui/Input'
+import { Button } from '../components/ui/Button'
+import { Card, CardContent, CardHeader } from '../components/ui/Card'
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '../components/ui/Table'
 import {
   fetchCalls,
   deleteCall,
@@ -10,7 +22,7 @@ import { useToast } from '../components/ToastProvider'
 export default function CallManagementPage() {
   const [calls, setCalls] = useState<Call[]>([])
   const navigate = useNavigate()
-  const [filterText, setFilterText] = useState('')
+  const [searchText, setSearchText] = useState('')
   const [sortField, setSortField] = useState<'title' | 'open' | null>(null)
   const [sortAsc, setSortAsc] = useState(true)
   const { showToast } = useToast()
@@ -50,8 +62,8 @@ export default function CallManagementPage() {
 
   const filtered = calls.filter(
     (c) =>
-      c.title.toLowerCase().includes(filterText.toLowerCase()) ||
-      (c.description || '').toLowerCase().includes(filterText.toLowerCase()),
+      c.title.toLowerCase().includes(searchText.toLowerCase()) ||
+      (c.description || '').toLowerCase().includes(searchText.toLowerCase()),
   )
   const sorted = [...filtered]
   if (sortField === 'title') {
@@ -69,55 +81,67 @@ export default function CallManagementPage() {
   return (
     <section className="space-y-6">
       <h1 className="text-xl font-bold">Call Management</h1>
-      <input
-        value={filterText}
-        onChange={(e) => setFilterText(e.target.value)}
-        placeholder="Filter"
-        className="border p-2 w-full"
-      />
-      <table className="min-w-full border">
-        <thead>
-          <tr className="bg-gray-100">
-            <th
-              className="p-2 text-left cursor-pointer"
-              onClick={() => handleSort('title')}
-            >
-              Title
-            </th>
-            <th className="p-2 text-left">Description</th>
-            <th
-              className="p-2 cursor-pointer"
-              onClick={() => handleSort('open')}
-            >
-              Open
-            </th>
-            <th className="p-2">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((c) => (
-            <tr key={c.id} className="border-t">
-              <td className="p-2">{c.title}</td>
-              <td className="p-2">{c.description}</td>
-              <td className="p-2 text-center">{c.is_open ? 'Yes' : 'No'}</td>
-              <td className="p-2 space-x-2 text-center">
-                <button onClick={() => onEdit(c)} className="text-blue-600 underline">
-                  Edit
-                </button>
-                <button onClick={() => onDelete(c.id)} className="text-red-600 underline">
-                  Delete
-                </button>
-                <Link
-                  to={`/admin/calls/${c.id}/applications`}
-                  className="text-green-600 underline"
-                >
-                  View Applications
-                </Link>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <Card>
+        <CardHeader className="flex justify-between items-center">
+          <h2 className="font-semibold text-lg">Calls</h2>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="max-w-xs">
+            <div className="relative">
+              <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+              <Input
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                placeholder="Search"
+                className="pl-7"
+              />
+            </div>
+          </div>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="cursor-pointer" onClick={() => handleSort('title')}>
+                    Title
+                  </TableHead>
+                  <TableHead className="hidden md:table-cell">Description</TableHead>
+                  <TableHead className="cursor-pointer text-center" onClick={() => handleSort('open')}>
+                    Open
+                  </TableHead>
+                  <TableHead className="text-center">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sorted.map((c, idx) => (
+                  <TableRow
+                    key={c.id}
+                    className={`${idx % 2 ? 'bg-gray-50' : ''} hover:bg-gray-50`}
+                  >
+                    <TableCell className="font-medium">{c.title}</TableCell>
+                    <TableCell className="hidden md:table-cell">{c.description}</TableCell>
+                    <TableCell className="text-center">{c.is_open ? 'Yes' : 'No'}</TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        <Button variant="outline" size="sm" onClick={() => onEdit(c.id)}>
+                          <Pencil className="h-4 w-4 mr-1" /> Edit
+                        </Button>
+                        <Button variant="destructive" size="sm" onClick={() => onDelete(c.id)}>
+                          <Trash2 className="h-4 w-4 mr-1" /> Delete
+                        </Button>
+                        <Button variant="link" size="sm" asChild>
+                          <Link to={`/admin/calls/${c.id}/applications`} className="flex items-center">
+                            <Eye className="h-4 w-4 mr-1" /> View
+                          </Link>
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
 
       <div>
         <Link to="/admin/calls/new" className="underline text-blue-600">Create New Call</Link>


### PR DESCRIPTION
## Summary
- add lucide-react dependency
- implement basic shadcn-style UI components (Button, Card, Input, Table)
- update Call Management page to use new components and search filter

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684a07ccf980832c82fc6d88d74d0bd1