### PR TITLE
Add enum for document formats

### DIFF
--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -1,10 +1,11 @@
 from sqlalchemy.orm import Session
 
 from ..models.document import DocumentDefinition
+from ..schemas.document import DocumentFormat
 
 
 def create_document_definition(
-    db: Session, call_id: int, name: str, allowed_formats: str, description: str | None = None
+    db: Session, call_id: int, name: str, allowed_formats: DocumentFormat, description: str | None = None
 ) -> DocumentDefinition:
     doc = DocumentDefinition(
         call_id=call_id,
@@ -22,7 +23,7 @@ def update_document_definition(
     db: Session,
     doc: DocumentDefinition,
     name: str | None = None,
-    allowed_formats: str | None = None,
+    allowed_formats: DocumentFormat | None = None,
     description: str | None = None,
 ) -> DocumentDefinition:
     if name is not None:

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -1,10 +1,16 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, CheckConstraint
 
 from ..database import Base
 
 
 class DocumentDefinition(Base):
     __tablename__ = "document_definitions"
+    __table_args__ = (
+        CheckConstraint(
+            "allowed_formats in ('pdf','image','text')",
+            name="ck_allowed_formats",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     call_id = Column(Integer, ForeignKey("calls.id"), nullable=False)

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -1,16 +1,24 @@
+from enum import Enum
+
 from pydantic import BaseModel, ConfigDict
+
+
+class DocumentFormat(str, Enum):
+    pdf = "pdf"
+    image = "image"
+    text = "text"
 
 
 class DocumentDefinitionCreate(BaseModel):
     name: str
     description: str | None = None
-    allowed_formats: str
+    allowed_formats: DocumentFormat
 
 
 class DocumentDefinitionUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
-    allowed_formats: str | None = None
+    allowed_formats: DocumentFormat | None = None
 
 
 class DocumentDefinitionOut(BaseModel):
@@ -18,6 +26,6 @@ class DocumentDefinitionOut(BaseModel):
     call_id: int
     name: str
     description: str | None = None
-    allowed_formats: str
+    allowed_formats: DocumentFormat
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/migrations/versions/0009_add_allowed_formats_check.py
+++ b/backend/migrations/versions/0009_add_allowed_formats_check.py
@@ -1,0 +1,31 @@
+"""add check constraint on document_definitions.allowed_formats
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2025-06-12 00:01:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        "ck_allowed_formats",
+        "document_definitions",
+        "allowed_formats in ('pdf','image','text')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_allowed_formats",
+        "document_definitions",
+        type_="check",
+    )
+


### PR DESCRIPTION
## Summary
- restrict `allowed_formats` using a new `DocumentFormat` enum
- enforce valid formats at the DB level with a `CheckConstraint`
- create Alembic migration for the new constraint

## Testing
- `python -m py_compile backend/app/schemas/document.py backend/app/crud/document.py backend/app/models/document.py`

------
https://chatgpt.com/codex/tasks/task_e_684a118a50e8832cb9000f66b50c3ceb