### PR TITLE
Add endpoint and frontend support for retrieving user's application

### DIFF
--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -109,6 +109,19 @@ def save_attachment(
     return {"detail": "Attachment saved"}
 
 
+@router.get("/{call_id}", response_model=ApplicationOut)
+def read_application(
+    call_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return the current user's application for the given call."""
+    application = get_application_by_user_and_call(db, current_user.id, call_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return application
+
+
 @router.get("/{call_id}/attachments", response_model=list[AttachmentOut])
 def list_application_attachments(
     call_id: int,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -59,6 +59,13 @@ export interface ApplicationData {
   content: string;
 }
 
+export interface Application {
+  id: number;
+  user_id: number;
+  call_id: number;
+  content: string;
+}
+
 export async function submitApplication(data: ApplicationData) {
   const res = await fetch(`${API_BASE}/applications/`, {
     method: 'POST',
@@ -67,6 +74,18 @@ export async function submitApplication(data: ApplicationData) {
   });
   if (!res.ok) {
     throw new Error('Failed to submit application');
+  }
+  return res.json();
+}
+
+export async function fetchApplicationByUserAndCall(
+  callId: number,
+): Promise<Application> {
+  const res = await fetch(`${API_BASE}/applications/${callId}`, {
+    headers: { ...authHeaders() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch application');
   }
   return res.json();
 }

--- a/frontend/src/pages/CallDetailPage.tsx
+++ b/frontend/src/pages/CallDetailPage.tsx
@@ -1,6 +1,10 @@
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { fetchCall, fetchDocumentDefinitions, fetchAttachments } from '../api'
+import {
+  fetchCall,
+  fetchDocumentDefinitions,
+  fetchApplicationByUserAndCall,
+} from '../api'
 import ApplicationDocumentsPage from './ApplicationDocumentsPage'
 import ApplicationPreview from './ApplicationPreview'
 
@@ -20,9 +24,9 @@ export default function CallDetailPage() {
     enabled: !!callId,
   })
 
-  const attachmentsQuery = useQuery({
-    queryKey: ['attachments', id],
-    queryFn: () => fetchAttachments(id),
+  const applicationQuery = useQuery({
+    queryKey: ['application', id],
+    queryFn: () => fetchApplicationByUserAndCall(id),
     enabled: !!callId,
     retry: false,
   })
@@ -31,7 +35,7 @@ export default function CallDetailPage() {
   if (callQuery.isLoading) return <p>Loading...</p>
   if (callQuery.isError) return <p>Failed to load call.</p>
 
-  const hasApplied = !attachmentsQuery.isError
+  const hasApplied = !applicationQuery.isError
 
   return (
     <section className="space-y-4">


### PR DESCRIPTION
## Summary
- expose user's application with new `GET /applications/{call_id}` route
- create `fetchApplicationByUserAndCall` helper in the API
- use the new helper in `CallDetailPage` to choose the right view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a118772a0832c9769b53b86941c36