### PR TITLE
Implement call-with-defs creation API

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -114,6 +114,26 @@ export async function createCall(data: CallInput): Promise<Call> {
   return res.json();
 }
 
+export interface CallWithDefsInput extends CallInput {
+  document_definitions: {
+    name: string
+    description?: string | null
+    allowed_formats: string
+  }[]
+}
+
+export async function apiCreateCallWithDefs(data: CallWithDefsInput): Promise<Call> {
+  const res = await fetch(`${API_BASE}/calls/with-defs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to create call')
+  }
+  return res.json()
+}
+
 export async function updateCall(id: number, data: CallInput): Promise<Call> {
   const res = await fetch(`${API_BASE}/calls/${id}`, {
     method: 'PUT',


### PR DESCRIPTION
## Summary
- introduce `apiCreateCallWithDefs` for posting a call with document definitions
- update create call page to use this new API
- adjust form schema to align with `CallWithDefs`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a11862fa0832ca8fe54a6ce901445