### PR TITLE
Enforce required documents on call creation

### DIFF
--- a/frontend/src/pages/CreateCallPage.tsx
+++ b/frontend/src/pages/CreateCallPage.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
   title: z.string().min(1),
   description: z.string().optional(),
   is_open: z.boolean().optional(),
-  document_definitions: z.array(docSchema),
+  document_definitions: z.array(docSchema).min(1),
 })
 
 type FormValues = z.infer<typeof schema>
@@ -89,6 +89,9 @@ export default function CreateCallPage() {
         <button type="button" onClick={() => append({ name: '', description: '', allowed_formats: 'pdf' })} className="bg-gray-200 px-2 py-1 rounded">
           Add Item
         </button>
+        {errors.document_definitions && (
+          <p className="text-red-600">{errors.document_definitions.message}</p>
+        )}
       </div>
       <button disabled={isSubmitting} className="bg-blue-600 text-white px-4 py-2 rounded">
         Create


### PR DESCRIPTION
## Summary
- require at least one document definition when creating a call
- show validation message when no required items are supplied

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a159c7c60832cbc52fb5610477bcb