### PR TITLE
Install wkhtmltopdf and document requirement

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+# Install wkhtmltopdf for PDF export functionality
+RUN apt-get update \
+    && apt-get install -y wkhtmltopdf \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 
 # Include migrations so Alembic can run inside the container
 COPY alembic.ini ./

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,6 +15,11 @@ docker-compose up --build
 
 The API will be available at `http://localhost:8000`.
 
+### Requirements
+
+The PDF export feature relies on [wkhtmltopdf](https://wkhtmltopdf.org/). The Docker image installs it automatically, but if you run the app locally you must install `wkhtmltopdf` yourself (e.g. `sudo apt-get install wkhtmltopdf`).
+
+
 ### Database migrations
 
 The project uses Alembic for managing schema migrations. Set your


### PR DESCRIPTION
## Summary
- install wkhtmltopdf inside the backend Docker image
- document wkhtmltopdf requirement in backend README

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a211e6640832c8158d2ca2e654db9