### PR TITLE
Fix auth state persistence on refresh

### DIFF
--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import React, { createContext, useContext, useState } from 'react'
 import { getToken, logout as apiLogout, storeToken } from '../api'
 import type { Role } from './RoleSlider';
 
@@ -12,17 +12,11 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [token, setToken] = useState<string | null>(null)
-  const [role, setRole] = useState<Role | null>(null)
-
-  // Restore auth state from localStorage. Navigation after login
-  // is handled in LoginPage via the onSuccess callback.
-  useEffect(() => {
-    const t = getToken();
-    const r = localStorage.getItem('role') as Role | null;
-    if (t) setToken(t);
-    if (r) setRole(r);
-  }, []);
+  const [token, setToken] = useState<string | null>(() => getToken())
+  const [role, setRole] = useState<Role | null>(() => {
+    const r = localStorage.getItem('role')
+    return r as Role | null
+  })
 
   const login = (tok: string, r: Role) => {
     storeToken(tok);


### PR DESCRIPTION
## Summary
- initialize AuthProvider state from `localStorage` so authentication info is available on first render

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a82a02f4c832c8b620debbe293962