### PR TITLE
Implement role-aware call detail page

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -45,5 +45,20 @@ def get_current_user(
 def get_current_admin(current_user: User = Depends(get_current_user)) -> User:
     """Ensure the current user has admin privileges."""
     if current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough privileges")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not enough privileges",
+        )
+    return current_user
+
+
+def get_current_admin_or_reviewer(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Allow access to admins and reviewers."""
+    if current_user.role not in (UserRole.ADMIN, UserRole.REVIEWER):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not enough privileges",
+        )
     return current_user

--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from app.dependencies import get_db
-from ..dependencies import get_current_admin
+from ..dependencies import get_current_admin, get_current_admin_or_reviewer
 from ..models.user import User
 
 from ..models.call import Call
@@ -91,7 +91,7 @@ def read_call(call_id: int, db: Session = Depends(get_db)):
 def list_call_applications(
     call_id: int,
     db: Session = Depends(get_db),
-    current_admin: User = Depends(get_current_admin),
+    current_user: User = Depends(get_current_admin_or_reviewer),
 ):
     call = get_call(db, call_id)
     if not call:


### PR DESCRIPTION
## Summary
- show different call detail views depending on user role
- allow reviewers to read applications via backend
- expose new dependency allowing admins and reviewers

## Testing
- `python -m py_compile $(git ls-files "*.py")`
- `npm --prefix frontend run lint` *(fails: Cannot find module '@eslint/js')*
- `npm --prefix frontend run build` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a82b0ab88832c81c6c6326b113718