### PR TITLE
Remove unused BaseModel import

### DIFF
--- a/backend/app/routes/calls.py
+++ b/backend/app/routes/calls.py
@@ -3,7 +3,6 @@ from fastapi.responses import Response as FastAPIResponse
 from fastapi.templating import Jinja2Templates
 import pdfkit
 from sqlalchemy.orm import Session
-from pydantic import BaseModel
 
 from app.dependencies import get_db
 from ..dependencies import get_current_admin, get_current_admin_or_reviewer


### PR DESCRIPTION
## Summary
- clean up `backend/app/routes/calls.py` by removing unused BaseModel import

## Testing
- `ruff check backend/app/routes/calls.py`

------
https://chatgpt.com/codex/tasks/task_e_684a8469db50832c99b85d62a9f7c733