### PR TITLE
Add call validation for documents

### DIFF
--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
 from ..dependencies import get_current_admin, get_current_user
+from ..crud.call import get_call
 from ..schemas.document import (
     DocumentDefinitionCreate,
     DocumentDefinitionOut,
@@ -26,6 +27,9 @@ def create_definition(
     db: Session = Depends(get_db),
     current_admin=Depends(get_current_admin),
 ):
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
     create_document_definition(
         db, call_id, doc_in.name, doc_in.allowed_formats, doc_in.description
     )
@@ -43,6 +47,9 @@ def update_definition(
     db: Session = Depends(get_db),
     current_admin=Depends(get_current_admin),
 ):
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
     doc = (
         db.query(DocumentDefinition)
         .filter(DocumentDefinition.id == doc_id, DocumentDefinition.call_id == call_id)
@@ -67,6 +74,9 @@ def delete_definition(
     db: Session = Depends(get_db),
     current_admin=Depends(get_current_admin),
 ):
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
     doc = (
         db.query(DocumentDefinition)
         .filter(DocumentDefinition.id == doc_id, DocumentDefinition.call_id == call_id)
@@ -84,4 +94,7 @@ def get_definitions(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
+    call = get_call(db, call_id)
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
     return list_document_definitions(db, call_id)

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,0 +1,77 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app import database
+from app.dependencies import get_db
+from app.dependencies import get_current_admin, get_current_user
+from app.models.user import UserRole
+from app.config import settings
+
+
+class DummyAdmin:
+    role = UserRole.ADMIN
+
+
+class DummyUser:
+    role = UserRole.APPLICANT
+
+
+@pytest.fixture()
+def client():
+    settings.create_tables = False
+    test_engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=test_engine
+    )
+
+    database.engine = test_engine
+    database.SessionLocal = TestingSessionLocal
+    database.Base.metadata.create_all(bind=test_engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_admin] = lambda: DummyAdmin()
+    app.dependency_overrides[get_current_user] = lambda: DummyUser()
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides = {}
+    database.Base.metadata.drop_all(bind=test_engine)
+
+
+def test_create_definition_invalid_call(client):
+    resp = client.post(
+        "/admin/calls/1/documents",
+        json={"name": "Doc", "allowed_formats": "pdf"},
+    )
+    assert resp.status_code == 404
+
+
+def test_update_definition_invalid_call(client):
+    resp = client.put(
+        "/admin/calls/1/documents/1",
+        json={},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_definition_invalid_call(client):
+    resp = client.delete("/admin/calls/1/documents/1")
+    assert resp.status_code == 404
+
+
+def test_get_definitions_invalid_call(client):
+    resp = client.get("/applications/1/documents")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- ensure document endpoints validate call IDs
- add tests for missing call IDs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684a849b7638832cb8964d4d64b45ea4