### PR TITLE
Fix file input clearing on document change

### DIFF
--- a/frontend/src/pages/applicant/Step2_Upload.tsx
+++ b/frontend/src/pages/applicant/Step2_Upload.tsx
@@ -128,6 +128,7 @@ export default function Step2_Upload() {
               {documents.find(d => d.id === selectedDocId)?.description}
             </p>
             <Input
+              key={selectedDocId}
               type="file"
               onChange={e => setSelectedFiles(Array.from(e.target.files || []))}
             />


### PR DESCRIPTION
## Summary
- ensure new file input is mounted when changing docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684d7045edc0832c9b205cccbfec6073