### PR TITLE
Implement attachment download API and UI updates

### DIFF
--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -95,6 +95,17 @@ export async function fetchAttachmentsByApplicationId(appId: number): Promise<At
   return res.json()
 }
 
+export async function downloadAttachment(attachmentId: number): Promise<Blob> {
+  const res = await fetch(
+    `${API_BASE}/applications/attachments/${attachmentId}/download`,
+    {
+      headers: authHeaders(),
+    }
+  )
+  if (!res.ok) throw new Error('Failed to download attachment')
+  return res.blob()
+}
+
 export async function deleteAttachment(attachmentId: number): Promise<void> {
   const res = await fetch(
     `${API_BASE}/applications/attachments/${attachmentId}`,

--- a/frontend/src/components/ApplicationList.tsx
+++ b/frontend/src/components/ApplicationList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { fetchApplications, type ApplicationDetail } from '../api';
+import { fetchApplications, type ApplicationDetail, downloadAttachment } from '../api';
 import { useToast } from './ToastProvider';
 
 interface Props {
@@ -60,14 +60,20 @@ export default function ApplicationList({ callId }: Props) {
                 <ul className="list-disc pl-5">
                   {app.attachments.map((att) => (
                     <li key={att.id}>
-                      <a
-                        href={`${import.meta.env.VITE_API_BASE || 'http://localhost:8000'}/applications/attachments/${att.id}/download`}
+                      <button
+                        onClick={async () => {
+                          try {
+                            const blob = await downloadAttachment(att.id)
+                            const url = URL.createObjectURL(blob)
+                            window.open(url, '_blank')
+                          } catch {
+                            showToast('Failed to download file', 'error')
+                          }
+                        }}
                         className="text-blue-600 underline"
-                        target="_blank"
-                        rel="noopener noreferrer"
                       >
                         {att.file_name}
-                      </a>
+                      </button>
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/components/AttachmentList.tsx
+++ b/frontend/src/components/AttachmentList.tsx
@@ -1,4 +1,5 @@
 import type { Attachment } from '../api'
+import { downloadAttachment } from '../api'
 
 
 interface Props {
@@ -10,14 +11,20 @@ export default function AttachmentList({ attachments }: Props) {
     <ul className="list-disc pl-5">
       {attachments.map((a) => (
         <li key={a.id}>
-          <a
-            href={`${import.meta.env.VITE_API_BASE || 'http://localhost:8000'}/applications/attachments/${a.id}/download`}
+          <button
+            onClick={async () => {
+              try {
+                const blob = await downloadAttachment(a.id)
+                const url = URL.createObjectURL(blob)
+                window.open(url, '_blank')
+              } catch {
+                // AttachmentList has no toast context by default; swallow errors
+              }
+            }}
             className="text-blue-600 underline"
-            target="_blank"
-            rel="noreferrer"
           >
             {a.file_name}
-          </a>
+          </button>
         </li>
       ))}
     </ul>

--- a/frontend/src/pages/admin/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/admin/ApplicationDetailPage.tsx
@@ -1,14 +1,15 @@
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { fetchApplicationDetails } from '../../api'
+import { fetchApplicationDetails, downloadAttachment } from '../../api'
 import type { ApplicationDetail, Attachment } from '../../api'
-import { API_BASE } from '../../api/config'
+import { useToast } from '../../components/ToastProvider'
 import { useAuth } from '../../context/AuthContext' // yolu senin yapına göre `components/AuthProvider` da olabilir
 
 export default function ApplicationDetailPage() {
   const { applicationId } = useParams<{ applicationId: string }>()
   const [application, setApplication] = useState<ApplicationDetail | null>(null)
   const { user } = useAuth()
+  const { showToast } = useToast()
 
   useEffect(() => {
     if (!applicationId) return
@@ -36,14 +37,20 @@ export default function ApplicationDetailPage() {
           <ul className="list-disc ml-5 space-y-1">
             {application.attachments.map((doc: Attachment) => (
               <li key={doc.id}>
-                <a
-                  href={`${API_BASE}/applications/attachments/${doc.id}/download`}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
+                  onClick={async () => {
+                    try {
+                      const blob = await downloadAttachment(doc.id)
+                      const url = URL.createObjectURL(blob)
+                      window.open(url, '_blank')
+                    } catch {
+                      showToast('Failed to download file', 'error')
+                    }
+                  }}
                   className="text-blue-600 hover:underline"
                 >
                   {doc.file_name}
-                </a>
+                </button>
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/applicant/Step2_Upload.tsx
+++ b/frontend/src/pages/applicant/Step2_Upload.tsx
@@ -7,6 +7,7 @@ import {
   uploadDocuments,
   deleteAttachment,
   fetchAttachmentsByApplicationId,
+  downloadAttachment,
   type Call,
   type Application,
   type DocumentDefinition,
@@ -140,14 +141,20 @@ export default function Step2_Upload() {
                 .filter(a => a.document_id === selectedDocId)
                 .map(a => (
                   <div key={a.id}>
-                    <a
-                      href={`${import.meta.env.VITE_API_BASE}/applications/attachments/${a.id}/download`}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                    <button
+                      onClick={async () => {
+                        try {
+                          const blob = await downloadAttachment(a.id)
+                          const url = URL.createObjectURL(blob)
+                          window.open(url, '_blank')
+                        } catch {
+                          showToast('Failed to download file', 'error')
+                        }
+                      }}
                       className="text-blue-600 underline text-sm"
                     >
                       {a.file_name}
-                    </a>
+                    </button>
                   </div>
                 ))}
             </div>

--- a/frontend/src/pages/applicant/Step3_Review.tsx
+++ b/frontend/src/pages/applicant/Step3_Review.tsx
@@ -5,6 +5,7 @@ import {
   fetchDocumentDefinitions,
   confirmDocuments,
   fetchApplicationByUserAndCall,
+  downloadAttachment,
   type Attachment,
   type DocumentDefinition,
   type Application,
@@ -68,14 +69,20 @@ export default function Step3_Review() {
               {files.length > 0 ? (
                 files.map(file => (
                   <li key={file.id}>
-                    <a
-                      href={`${import.meta.env.VITE_API_BASE}/applications/attachments/${file.id}/download`}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                    <button
+                      onClick={async () => {
+                        try {
+                          const blob = await downloadAttachment(file.id)
+                          const url = URL.createObjectURL(blob)
+                          window.open(url, '_blank')
+                        } catch {
+                          showToast('Failed to download file', 'error')
+                        }
+                      }}
                       className="text-blue-600 underline"
                     >
                       {file.file_name}
-                    </a>
+                    </button>
                   </li>
                 ))
               ) : (


### PR DESCRIPTION
## Summary
- implement `downloadAttachment` API helper
- update lists and pages to fetch file blobs before opening

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d7044f7dc832c831ea7c067476587