### PR TITLE
Implement helper for attachment downloads

### DIFF
--- a/frontend/src/components/ApplicationList.tsx
+++ b/frontend/src/components/ApplicationList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { fetchApplications, type ApplicationDetail, downloadAttachment } from '../api';
 import { useToast } from './ToastProvider';
+import { downloadBlob } from '../lib/download';
 
 interface Props {
   callId: number;
@@ -64,8 +65,7 @@ export default function ApplicationList({ callId }: Props) {
                         onClick={async () => {
                           try {
                             const blob = await downloadAttachment(att.id)
-                            const url = URL.createObjectURL(blob)
-                            window.open(url, '_blank')
+                            downloadBlob(blob, att.file_name)
                           } catch {
                             showToast('Failed to download file', 'error')
                           }

--- a/frontend/src/components/AttachmentList.tsx
+++ b/frontend/src/components/AttachmentList.tsx
@@ -1,5 +1,6 @@
 import type { Attachment } from '../api'
 import { downloadAttachment } from '../api'
+import { downloadBlob } from '../lib/download'
 
 
 interface Props {
@@ -15,8 +16,7 @@ export default function AttachmentList({ attachments }: Props) {
             onClick={async () => {
               try {
                 const blob = await downloadAttachment(a.id)
-                const url = URL.createObjectURL(blob)
-                window.open(url, '_blank')
+                downloadBlob(blob, a.file_name)
               } catch {
                 // AttachmentList has no toast context by default; swallow errors
               }

--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -1,0 +1,10 @@
+export function downloadBlob(blob: Blob, name: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = name
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}

--- a/frontend/src/pages/admin/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/admin/ApplicationDetailPage.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { fetchApplicationDetails, downloadAttachment } from '../../api'
 import type { ApplicationDetail, Attachment } from '../../api'
+import { downloadBlob } from '../../lib/download'
 import { useToast } from '../../components/ToastProvider'
 import { useAuth } from '../../context/AuthContext' // yolu senin yapına göre `components/AuthProvider` da olabilir
 
@@ -41,8 +42,7 @@ export default function ApplicationDetailPage() {
                   onClick={async () => {
                     try {
                       const blob = await downloadAttachment(doc.id)
-                      const url = URL.createObjectURL(blob)
-                      window.open(url, '_blank')
+                      downloadBlob(blob, doc.file_name)
                     } catch {
                       showToast('Failed to download file', 'error')
                     }

--- a/frontend/src/pages/applicant/Step2_Upload.tsx
+++ b/frontend/src/pages/applicant/Step2_Upload.tsx
@@ -17,6 +17,7 @@ import { useToast } from '../../components/ToastProvider'
 import { Button } from '../../components/ui/Button'
 import { Input } from '../../components/ui/Input'
 import ConfirmModal from '../../components/ui/ConfirmModal'
+import { downloadBlob } from '../../lib/download'
 
 export default function Step2_Upload() {
   const { callId } = useParams<{ callId: string }>()
@@ -179,8 +180,7 @@ export default function Step2_Upload() {
                       onClick={async () => {
                         try {
                           const blob = await downloadAttachment(a.id)
-                          const url = URL.createObjectURL(blob)
-                          window.open(url, '_blank')
+                          downloadBlob(blob, a.file_name)
                         } catch {
                           showToast('Failed to download file', 'error')
                         }

--- a/frontend/src/pages/applicant/Step3_Review.tsx
+++ b/frontend/src/pages/applicant/Step3_Review.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../api'
 import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ToastProvider'
+import { downloadBlob } from '../../lib/download'
 
 export default function Step3_Review() {
   const { callId } = useParams<{ callId: string }>()
@@ -73,8 +74,7 @@ export default function Step3_Review() {
                       onClick={async () => {
                         try {
                           const blob = await downloadAttachment(file.id)
-                          const url = URL.createObjectURL(blob)
-                          window.open(url, '_blank')
+                          downloadBlob(blob, file.file_name)
                         } catch {
                           showToast('Failed to download file', 'error')
                         }


### PR DESCRIPTION
## Summary
- add `downloadBlob` helper to trigger file downloads
- use `downloadBlob` when clicking attachments

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684d77ce9c8c832cac3667e611d946db