### PR TITLE
Handle confirm duplicates

### DIFF
--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -154,7 +154,10 @@ export async function confirmDocuments(applicationId: number): Promise<void> {
     method: 'POST',
     headers: authHeaders(),
   })
-  if (!res.ok) throw new Error('Failed to confirm documents')
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.detail || 'Failed to confirm documents')
+  }
 }
 
 // 9. Başvuruyu SUBMITTED yap

--- a/frontend/src/pages/applicant/Step4_Submit.tsx
+++ b/frontend/src/pages/applicant/Step4_Submit.tsx
@@ -39,10 +39,14 @@ export default function Step4_Submit() {
     if (!application) return
     try {
       await confirmDocuments(application.id)
-      submitMutate()
-    } catch {
-      showToast('Failed to confirm documents', 'error')
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      if (!msg.includes('Attachments already confirmed')) {
+        showToast(msg || 'Failed to confirm documents', 'error')
+        return
+      }
     }
+    submitMutate()
   }
 
   if (isLoading) return <p className="p-4">Loading application…</p>


### PR DESCRIPTION
## Summary
- parse error message in `confirmDocuments` to surface server errors
- ignore already confirmed attachment errors and continue submission

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d77d365ec832ca4ce2b230512fc32