### PR TITLE
Fix sequential document creation

### DIFF
--- a/frontend/src/api/document.ts
+++ b/frontend/src/api/document.ts
@@ -6,7 +6,8 @@ export interface DocumentDefinition { id: number; call_id: number; name: string;
 export async function fetchDocumentDefinitions(callId: number): Promise<DocumentDefinition[]> {
   const res = await fetch(`${API_BASE}/calls/${callId}/documents`, { headers: authHeaders() })
   if (!res.ok) throw new Error('Failed to load document definitions')
-  return res.json()
+  const docs: DocumentDefinition[] = await res.json()
+  return docs.sort((a, b) => a.id - b.id)
 }
 
 export async function createDocumentDefinition(callId: number, data: Omit<DocumentDefinition,'id'|'call_id'>): Promise<DocumentDefinition[]> {

--- a/frontend/src/pages/admin/CreateCallPage.tsx
+++ b/frontend/src/pages/admin/CreateCallPage.tsx
@@ -61,15 +61,13 @@ export default function CreateCallPage() {
       })
 
       if (data.documents?.length > 0) {
-        await Promise.all(
-          data.documents.map((d) =>
-            createDocumentDefinition(newCall.id, {
-              name: d.name,
-              description: d.description ?? null,
-              allowed_formats: d.allowed_formats,
-            })
-          )
-        )
+        for (const d of data.documents) {
+          await createDocumentDefinition(newCall.id, {
+            name: d.name,
+            description: d.description ?? null,
+            allowed_formats: d.allowed_formats,
+          })
+        }
       }
 
       showToast('Call created successfully', 'success')

--- a/frontend/src/pages/admin/EditCallPage.tsx
+++ b/frontend/src/pages/admin/EditCallPage.tsx
@@ -131,20 +131,19 @@ export default function EditCallPage() {
         await Promise.all(toDelete.map(docId => deleteDocumentDefinition(id, docId)))
       }
 
-      // Update or create docs
-      await Promise.all(
-        data.items.map(async doc => {
-          const input = {
-            name: doc.name,
-            description: doc.description || '',
-            allowed_formats: doc.allowed_formats
-          }
-          if (doc.id) {
-            return updateDocumentDefinition(id, doc.id, input)
-          }
-          return createDocumentDefinition(id, input)
-        })
-      )
+      // Update or create docs sequentially to preserve order
+      for (const doc of data.items) {
+        const input = {
+          name: doc.name,
+          description: doc.description || '',
+          allowed_formats: doc.allowed_formats,
+        }
+        if (doc.id) {
+          await updateDocumentDefinition(id, doc.id, input)
+        } else {
+          await createDocumentDefinition(id, input)
+        }
+      }
 
       showToast('Call updated successfully', 'success')
       navigate('/admin/calls')


### PR DESCRIPTION
## Summary
- create documents sequentially when creating a call
- sort fetched documents by id
- update documents sequentially when editing a call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684d77da428c832c8c75b46b0088aff7