### PR TITLE
Add role-based auth routing

### DIFF
--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,12 +1,10 @@
 // src/components/LoginForm.tsx
 import { useForm } from 'react-hook-form'
-import { useState } from 'react'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { login as apiLogin } from '../api'
 import type { LoginData } from '../api'
 import { useToast } from './ToastProvider'
-import RoleSlider from './RoleSlider'
 import type { Role } from './RoleSlider'
 import { useAuth } from './AuthProvider'
 
@@ -16,17 +14,17 @@ const schema = z.object({
 })
 
 interface Props {
+  role: Role
   onSuccess?: (role: Role) => void
 }
 
-export default function LoginForm({ onSuccess }: Props) {
+export default function LoginForm({ role, onSuccess }: Props) {
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
   } = useForm<Omit<LoginData, 'role'>>({ resolver: zodResolver(schema) })
   const { showToast } = useToast()
-  const [role, setRole] = useState<Role>('applicant')
   const { login } = useAuth()
 
   const onSubmit = handleSubmit(async (data) => {
@@ -51,8 +49,6 @@ export default function LoginForm({ onSuccess }: Props) {
   return (
     <form onSubmit={onSubmit} className="space-y-6">
       <p className="text-center text-lg">Login</p>
-
-      <RoleSlider value={role} onChange={setRole} />
 
       <div>
         <label htmlFor="login-email" className="block text-sm font-medium text-gray-700">

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -39,8 +39,8 @@ function Navbar() {
             </button>
           ) : (
             <>
-              <Link to="/login" className="bg-blue-500 px-3 py-1 rounded">Login</Link>
-              <Link to="/register" className="bg-green-500 px-3 py-1 rounded">Sign Up</Link>
+              <Link to="/auth" className="bg-blue-500 px-3 py-1 rounded">Login</Link>
+              <Link to="/auth" className="bg-green-500 px-3 py-1 rounded">Sign Up</Link>
             </>
           )}
         </div>

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -3,6 +3,7 @@ import { useToast } from './ToastProvider'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { registerUser } from '../api'
 import type { RegisterData } from '../api'
+import type { Role } from './RoleSlider'
 import { z } from 'zod'
 import { Link } from 'react-router-dom'
 
@@ -10,7 +11,6 @@ import { Link } from 'react-router-dom'
 const schema = z.object({
   email: z.string().email('Invalid email address'),
   password: z.string().min(6, 'Password must be at least 6 characters'),
-  role: z.enum(['applicant', 'reviewer', 'admin']),
   firstName: z.string().min(1, 'First name is required'),
   lastName: z.string().min(1, 'Last name is required'),
   organization: z.string().min(1, 'Organization is required'),
@@ -18,17 +18,18 @@ const schema = z.object({
 
 
 interface Props {
+  role: Role
   onSuccess?: () => void
 }
 
-export default function RegisterForm({ onSuccess }: Props) {
+export default function RegisterForm({ role, onSuccess }: Props) {
   const { register, handleSubmit, formState: { errors, isSubmitting } } =
-    useForm<RegisterData>({ resolver: zodResolver(schema) })
+    useForm<Omit<RegisterData, 'role'>>({ resolver: zodResolver(schema) })
   const { showToast } = useToast()
 
-  const onSubmit = async (data: RegisterData) => {
+  const onSubmit = async (data: Omit<RegisterData, 'role'>) => {
     try {
-      await registerUser(data)
+      await registerUser({ ...data, role })
       showToast('Registration successful! Check your email to verify.', 'success')
       onSuccess?.()
     } catch {
@@ -100,22 +101,6 @@ export default function RegisterForm({ onSuccess }: Props) {
         {errors.organization && <p className="text-sm text-red-600">{errors.organization.message}</p>}
       </div>
 
-      {/* Role */}
-      <div>
-        <label htmlFor="role" className="block text-sm font-medium text-gray-700">Role</label>
-        <select
-          id="role"
-          {...register('role')}
-          disabled={isSubmitting}
-          className="mt-1 block w-full border rounded px-4 py-3"
-        >
-          <option value="">Select role</option>
-          <option value="applicant">Applicant</option>
-          <option value="reviewer">Reviewer</option>
-          <option value="admin">Administrator</option>
-        </select>
-        {errors.role && <p className="text-sm text-red-600">{errors.role.message}</p>}
-      </div>
 
       {/* Submit */}
       <button

--- a/frontend/src/pages/AuthLandingPage.tsx
+++ b/frontend/src/pages/AuthLandingPage.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom'
+import type { Role } from '../components/RoleSlider'
+
+const roles: Role[] = ['applicant', 'reviewer', 'admin']
+
+export default function AuthLandingPage() {
+  return (
+    <section className="w-full bg-gray-50 py-16 px-4">
+      <div className="max-w-md mx-auto space-y-6">
+        <h1 className="text-2xl font-bold text-center">Choose Your Role</h1>
+        {roles.map((role) => (
+          <div key={role} className="bg-white p-4 rounded shadow text-center space-y-2">
+            <h2 className="text-lg font-semibold capitalize">{role}</h2>
+            <div className="flex justify-center space-x-4">
+              <Link
+                to={`/login/${role}`}
+                className="bg-blue-500 text-white px-4 py-2 rounded"
+              >
+                Login
+              </Link>
+              <Link
+                to={`/register/${role}`}
+                className="bg-green-500 text-white px-4 py-2 rounded"
+              >
+                Sign Up
+              </Link>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -62,7 +62,7 @@ export default function HomePage() {
             Browse Calls
           </Link>
           <Link
-            to="/register"
+            to="/auth"
             className="bg-green-600 text-white px-6 py-3 rounded-lg shadow hover:bg-green-700 transition"
           >
             Get Started

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,14 +1,21 @@
 import LoginForm from '../components/LoginForm'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
+import type { Role } from '../components/RoleSlider'
 
 export default function LoginPage() {
   const navigate = useNavigate()
+  const { role } = useParams<{ role: Role }>()
 
   return (
     <section className="w-full bg-gray-50 py-16 px-4">
       <div className="max-w-md mx-auto bg-white p-8 rounded-lg shadow-lg">
         <h1 className="text-2xl font-bold text-center mb-6">Welcome Back</h1>
-        <LoginForm onSuccess={(role) => navigate(role === 'admin' ? '/admin/calls' : '/calls')} />
+        {role && (
+          <LoginForm
+            role={role}
+            onSuccess={() => navigate(role === 'admin' ? '/admin/calls' : '/calls')}
+          />
+        )}
       </div>
     </section>
   )

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,13 +1,17 @@
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import RegisterForm from '../components/RegisterForm'
+import type { Role } from '../components/RoleSlider'
 
 export default function RegisterPage() {
   const navigate = useNavigate()
+  const { role } = useParams<{ role: Role }>()
   return (
     <section className="w-full bg-gray-50 py-16 px-4">
       <div className="max-w-md mx-auto bg-white p-8 rounded-lg shadow-lg">
         <h1 className="text-2xl font-bold text-center mb-6">Create Your Account</h1>
-        <RegisterForm onSuccess={() => navigate('/login')} />
+        {role && (
+          <RegisterForm role={role} onSuccess={() => navigate(`/login/${role}`)} />
+        )}
       </div>
     </section>
   )

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -7,6 +7,7 @@ const HomePage = React.lazy(() => import('./pages/HomePage'))
 const AboutPage = React.lazy(() => import('./pages/AboutPage'))
 const RegisterPage = React.lazy(() => import('./pages/RegisterPage'))
 const LoginPage = React.lazy(() => import('./pages/LoginPage'))
+const AuthLandingPage = React.lazy(() => import('./pages/AuthLandingPage'))
 const VerifyEmailPage = React.lazy(() => import('./pages/VerifyEmailPage'))
 const PasswordResetRequestPage = React.lazy(() => import('./pages/PasswordResetRequestPage'))
 const PasswordResetConfirmPage = React.lazy(() => import('./pages/PasswordResetConfirmPage'))
@@ -30,8 +31,11 @@ export const appRoutes = [
   // Public
   { path: '/', element: <HomePage /> },
   { path: '/about', element: <AboutPage /> },
-  { path: '/register', element: <RegisterPage /> },
-  { path: '/login', element: <LoginPage /> },
+  { path: '/auth', element: <AuthLandingPage /> },
+  { path: '/register/:role', element: <RegisterPage /> },
+  { path: '/register', element: <Navigate to="/auth" replace /> },
+  { path: '/login/:role', element: <LoginPage /> },
+  { path: '/login', element: <Navigate to="/auth" replace /> },
   { path: '/verify/:token', element: <VerifyEmailPage /> },
   { path: '/password-reset', element: <PasswordResetRequestPage /> },
   { path: '/password-reset/:token', element: <PasswordResetConfirmPage /> },


### PR DESCRIPTION
## Summary
- add a landing page with role selection
- update login and register pages to accept role param
- use route role in forms
- adjust navbar and homepage to use new auth page
- route `/login/:role` and `/register/:role`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ed5dc6c44832cbbf2fea8792f3139