### PR TITLE
Add reviewers listing route

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,7 +1,7 @@
 from .applications import router as application_router
 from .calls import router as call_router
 from .documents import router as document_router
-from .users import router as user_router, auth_router
+from .users import router as user_router, auth_router, list_reviewers
 from .review import router as review_router
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "call_router",
     "document_router",
     "user_router",
+    "list_reviewers",
     "auth_router",
     "review_router",
 ]

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -7,7 +7,7 @@ from jose import jwt
 
 from app.dependencies import get_db
 from ..dependencies import get_current_user, get_current_admin
-from ..models.user import User as UserModel
+from ..models.user import User as UserModel, UserRole
 from ..schemas.user import (
     UserCreate,
     UserOut,
@@ -134,6 +134,14 @@ def list_users(
     current_admin = Depends(get_current_admin),
 ):
     return db.query(UserModel).all()
+
+
+@router.get("/admin/reviewers", response_model=list[UserOut])
+def list_reviewers(
+    db: Session = Depends(get_db),
+    current_admin = Depends(get_current_admin)
+):
+    return db.query(UserModel).filter(UserModel.role == UserRole.REVIEWER).all()
 
 
 @router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,59 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app import database
+from app.dependencies import get_db, get_current_admin
+from app.models.user import User, UserRole
+from app.config import settings
+
+
+class DummyAdmin:
+    role = UserRole.ADMIN
+
+
+@pytest.fixture()
+def client():
+    settings.create_tables = False
+    test_engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+
+    database.engine = test_engine
+    database.SessionLocal = TestingSessionLocal
+    database.Base.metadata.create_all(bind=test_engine)
+
+    # Populate with some users
+    session = TestingSessionLocal()
+    session.add(User(email="reviewer@example.com", hashed_password="x", role=UserRole.REVIEWER))
+    session.add(User(email="applicant@example.com", hashed_password="x", role=UserRole.APPLICANT))
+    session.commit()
+    session.close()
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_admin] = lambda: DummyAdmin()
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides = {}
+    database.Base.metadata.drop_all(bind=test_engine)
+
+
+def test_list_reviewers(client):
+    resp = client.get("/users/admin/reviewers")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["email"] == "reviewer@example.com"
+    assert data[0]["role"] == "reviewer"


### PR DESCRIPTION
## Summary
- list reviewers from admin-only endpoint
- export the new function via `__all__`
- test reviewer listing route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ed68f9a14832c833870f4c55fe464