### PR TITLE
Accept update schema for document definitions

### DIFF
--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from ..models.document import DocumentDefinition
-from ..schemas.document import DocumentFormat
+from ..schemas.document import DocumentFormat, DocumentDefinitionUpdate
 
 
 def create_document_definition(
@@ -23,10 +23,12 @@ def create_document_definition(
     return doc
 
 
-def update_document_definition(db: Session, doc: DocumentDefinition, doc_update: dict) -> DocumentDefinition:
+def update_document_definition(
+    db: Session, doc: DocumentDefinition, doc_update: DocumentDefinitionUpdate
+) -> DocumentDefinition:
     data = doc_update.model_dump(exclude_unset=True)
-    for key, value in data.items():
-        setattr(doc, key, value)
+    for field, value in data.items():
+        setattr(doc, field, value)
     db.commit()
     db.refresh(doc)
     return doc

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -69,12 +69,7 @@ def update_definition(
     if not doc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
 
-    updated = update_document_definition(
-        db, doc,
-        name=doc_in.name,
-        allowed_formats=doc_in.allowed_formats,
-        description=doc_in.description
-    )
+    updated = update_document_definition(db, doc, doc_in)
     return updated
 
 @router.delete("/{doc_id}", status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary
- adjust `update_document_definition` to take `DocumentDefinitionUpdate`
- update document routes to send the update schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ed6a20370832cb144e65e303fadc1