### PR TITLE
Fix admin reviewers endpoint

### DIFF
--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -186,7 +186,7 @@ export async function assignReviewer(applicationId: number, reviewerId: number):
 
 // 11. Hakem listesini getir (admin için)
 export async function fetchReviewers(): Promise<User[]> {
-  const res = await fetch(`${API_BASE}/admin/reviewers`, {
+  const res = await fetch(`${API_BASE}/users/admin/reviewers`, {
     headers: authHeaders(),
   })
   if (!res.ok) throw new Error('Failed to fetch reviewers')


### PR DESCRIPTION
## Summary
- update reviewers endpoint

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ee712228c832c860fdf7be8bfc793