### PR TITLE
Fix AuthProvider context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,11 @@ import React, { Suspense } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Navbar from './components/Navbar'
 import { ToastProvider } from './components/ToastProvider'
-import { AuthProvider } from './components/AuthProvider'
 import { appRoutes } from './routes'
 
 function App() {
   return (
     <ToastProvider>
-      <AuthProvider>
         <div className="flex flex-col min-h-screen">
           <Navbar />
           <main className="w-full max-w-screen-2xl mx-auto p-4 space-y-8 flex-grow">
@@ -30,7 +28,6 @@ function App() {
             </Suspense>
           </main>
         </div>
-      </AuthProvider>
     </ToastProvider>
   )
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider } from './components/AuthProvider'
 import './index.css' // Global Tailwind styles
 import App from './App'
 
@@ -10,9 +11,11 @@ const client = new QueryClient() // React Query client for caching and async sta
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <QueryClientProvider client={client}>
-        <App />
-      </QueryClientProvider>
+      <AuthProvider>
+        <QueryClientProvider client={client}>
+          <App />
+        </QueryClientProvider>
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- move `AuthProvider` to the main entry so all routes share the auth context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ee5a5f388832cbda40eccd792905c