### PR TITLE
Add reviewer dashboard and application review pages

### DIFF
--- a/frontend/src/api/review.ts
+++ b/frontend/src/api/review.ts
@@ -65,3 +65,17 @@ export async function deleteReview(id: number): Promise<void> {
   })
   if (!res.ok) throw new Error('Failed to delete review')
 }
+
+// Reviewer downloads an attachment for review
+export async function downloadAttachmentForReview(
+  attachmentId: number
+): Promise<Blob> {
+  const res = await fetch(
+    `${API_BASE}/attachments/${attachmentId}/download`,
+    {
+      headers: { ...authHeaders() },
+    }
+  )
+  if (!res.ok) throw new Error('Failed to download attachment')
+  return res.blob()
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -29,6 +29,11 @@ function Navbar() {
               Manage Calls
             </Link>
           )}
+          {token && role === 'reviewer' && (
+            <Link to="/reviewer" className="hover:underline">
+              My Reviews
+            </Link>
+          )}
         </div>
 
         {/* Auth buttons */}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -17,7 +17,7 @@ export default function DashboardPage() {
         navigate('/admin/calls')
         break
       case 'reviewer':
-        navigate('/reviewer/reviews')
+        navigate('/reviewer')
         break
       case 'applicant':
         navigate('/calls')

--- a/frontend/src/pages/reviewer/ReviewApplicationPage.tsx
+++ b/frontend/src/pages/reviewer/ReviewApplicationPage.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import {
+  fetchApplicationDetails,
+  fetchMyReviews,
+  submitReview,
+  updateReview,
+  downloadAttachmentForReview,
+  type ApplicationDetail,
+  type Attachment,
+} from '../../api'
+import { useToast } from '../../components/ToastProvider'
+import { downloadBlob } from '../../lib/download'
+
+export default function ReviewApplicationPage() {
+  const { applicationId } = useParams<{ applicationId: string }>()
+  const [application, setApplication] = useState<ApplicationDetail | null>(null)
+  const [score, setScore] = useState(0)
+  const [comment, setComment] = useState('')
+  const [reviewId, setReviewId] = useState<number | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const { showToast } = useToast()
+
+  useEffect(() => {
+    if (!applicationId) return
+    const load = async () => {
+      try {
+        const [app, myReviews] = await Promise.all([
+          fetchApplicationDetails(Number(applicationId)),
+          fetchMyReviews().catch(() => []),
+        ])
+        setApplication(app)
+        const myReview = myReviews.find(r => r.application_id === Number(applicationId))
+        if (myReview) {
+          setScore(myReview.score)
+          setComment(myReview.comment || '')
+          setReviewId(myReview.id)
+        }
+      } catch {
+        showToast('Failed to load application', 'error')
+      }
+    }
+    load()
+  }, [applicationId, showToast])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!applicationId) return
+    try {
+      if (reviewId) {
+        await updateReview(reviewId, { score, comment })
+        showToast('Review updated', 'success')
+      } else {
+        const r = await submitReview({
+          application_id: Number(applicationId),
+          score,
+          comment,
+        })
+        setReviewId(r.id)
+        showToast('Review submitted', 'success')
+      }
+    } catch {
+      showToast('Failed to submit review', 'error')
+    }
+  }
+
+  const handleView = async (att: Attachment) => {
+    try {
+      const blob = await downloadAttachmentForReview(att.id)
+      const url = URL.createObjectURL(blob)
+      setPreviewUrl(url)
+    } catch {
+      showToast('Failed to load attachment', 'error')
+    }
+  }
+
+  if (!application) return <p className="p-4">Loading...</p>
+
+  return (
+    <section className="space-y-6">
+      <h1 className="text-xl font-bold">Application #{application.id}</h1>
+
+      <div className="space-y-1">
+        <p>
+          <strong>Applicant:</strong> {application.user_email}
+        </p>
+        <p>
+          <strong>Documents Confirmed:</strong>{' '}
+          {application.documents_confirmed ? 'Yes' : 'No'}
+        </p>
+      </div>
+
+      <div>
+        <h2 className="font-semibold mb-2">Attachments</h2>
+        {application.attachments.length > 0 ? (
+          <ul className="list-disc ml-5 space-y-1">
+            {application.attachments.map(att => (
+              <li key={att.id}>
+                <button
+                  onClick={() => handleView(att)}
+                  className="text-blue-600 underline mr-2"
+                >
+                  View
+                </button>
+                <button
+                  onClick={async () => {
+                    try {
+                      const blob = await downloadAttachmentForReview(att.id)
+                      downloadBlob(blob, att.file_name)
+                    } catch {
+                      showToast('Failed to download', 'error')
+                    }
+                  }}
+                  className="text-blue-600 underline"
+                >
+                  Download
+                </button>
+                <span className="ml-2">{att.file_name}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No attachments.</p>
+        )}
+      </div>
+
+      {previewUrl && (
+        <div>
+          {previewUrl.endsWith('.pdf') ? (
+            <iframe
+              src={previewUrl}
+              className="w-full h-96 border"
+              title="Preview"
+            />
+          ) : (
+            <img src={previewUrl} alt="preview" className="max-h-96" />
+          )}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-medium mb-1">Score</label>
+          <input
+            type="number"
+            value={score}
+            onChange={e => setScore(Number(e.target.value))}
+            className="border p-2 rounded w-20"
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Comment</label>
+          <textarea
+            value={comment}
+            onChange={e => setComment(e.target.value)}
+            className="border p-2 rounded w-full"
+            rows={4}
+          />
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+          {reviewId ? 'Update Review' : 'Submit Review'}
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/frontend/src/pages/reviewer/ReviewDashboard.tsx
+++ b/frontend/src/pages/reviewer/ReviewDashboard.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  fetchCalls,
+  fetchApplications,
+  fetchMyReviews,
+  type Call,
+  type ApplicationDetail,
+  type ReviewOut,
+  type User,
+} from '../../api'
+import { useToast } from '../../components/ToastProvider'
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '../../components/ui/Table'
+
+interface ReviewApp extends ApplicationDetail {
+  callTitle: string
+}
+
+export default function ReviewDashboard() {
+  const [apps, setApps] = useState<ReviewApp[]>([])
+  const [reviewedIds, setReviewedIds] = useState<number[]>([])
+  const [filter, setFilter] = useState<'needs' | 'reviewed' | 'all'>('needs')
+  const [search, setSearch] = useState('')
+  const { showToast } = useToast()
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const token = localStorage.getItem('token')
+        if (!token) return
+        const myId = JSON.parse(atob(token.split('.')[1])).sub
+
+        const [calls, myReviews] = await Promise.all([
+          fetchCalls(),
+          fetchMyReviews().catch(() => [] as ReviewOut[]),
+        ])
+        setReviewedIds(myReviews.map(r => r.application_id))
+
+        const results: ReviewApp[] = []
+        for (const call of calls) {
+          try {
+            const list = await fetchApplications(call.id)
+            list.forEach(app => {
+              if (app.reviewers?.some((r: User) => r.id == myId)) {
+                results.push({ ...app, callTitle: call.title })
+              }
+            })
+          } catch {
+            // ignore per-call errors
+          }
+        }
+        setApps(results)
+      } catch {
+        showToast('Failed to load data', 'error')
+      }
+    }
+    load()
+  }, [showToast])
+
+  const filtered = apps
+    .filter(a => {
+      if (filter === 'needs') return !reviewedIds.includes(a.id)
+      if (filter === 'reviewed') return reviewedIds.includes(a.id)
+      return true
+    })
+    .filter(
+      a =>
+        a.callTitle.toLowerCase().includes(search.toLowerCase()) ||
+        a.user_email.toLowerCase().includes(search.toLowerCase())
+    )
+
+  return (
+    <section className="space-y-6">
+      <h1 className="text-xl font-bold">Review Dashboard</h1>
+      <div className="flex flex-wrap gap-2 items-center">
+        <input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search..."
+          className="border p-2 rounded flex-1 max-w-md"
+        />
+        <select
+          value={filter}
+          onChange={e => setFilter(e.target.value as any)}
+          className="border p-2 rounded"
+        >
+          <option value="needs">Needs review</option>
+          <option value="reviewed">Reviewed</option>
+          <option value="all">All</option>
+        </select>
+      </div>
+      <div className="overflow-x-auto">
+        <Table className="min-w-[600px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Call</TableHead>
+              <TableHead>Applicant</TableHead>
+              <TableHead className="text-center">Documents</TableHead>
+              <TableHead className="text-center">Status</TableHead>
+              <TableHead className="text-center">Action</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map((app, idx) => (
+              <TableRow key={app.id} className={idx % 2 ? 'bg-gray-50' : ''}>
+                <TableCell>{app.callTitle}</TableCell>
+                <TableCell>{app.user_email}</TableCell>
+                <TableCell className="text-center">
+                  {app.documents_confirmed ? 'Submitted' : 'Draft'}
+                </TableCell>
+                <TableCell className="text-center">
+                  {reviewedIds.includes(app.id) ? 'Reviewed' : 'Needs review'}
+                </TableCell>
+                <TableCell className="text-center">
+                  <Link
+                    to={`/reviewer/applications/${app.id}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    View
+                  </Link>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -24,6 +24,8 @@ const CreateCallPage = React.lazy(() => import('./pages/admin/CreateCallPage'))
 const EditCallPage = React.lazy(() => import('./pages/admin/EditCallPage'))
 const CallDocumentsPage = React.lazy(() => import('./pages/admin/CallDocumentsPage'))
 const CallApplicationsPage = React.lazy(() => import('./pages/reviewer/CallApplicationsPage'))
+const ReviewDashboard = React.lazy(() => import('./pages/reviewer/ReviewDashboard'))
+const ReviewApplicationPage = React.lazy(() => import('./pages/reviewer/ReviewApplicationPage'))
 const ApplicationDetailPage = React.lazy(() => import('./pages/admin/ApplicationDetailPage'))
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage'))
 
@@ -55,6 +57,8 @@ export const appRoutes = [
   },
 
   // Reviewer / Kullanıcı
+  { path: '/reviewer', element: <PrivateRoute roles={["reviewer"]}><ReviewDashboard /></PrivateRoute> },
+  { path: '/reviewer/applications/:applicationId', element: <PrivateRoute roles={["reviewer"]}><ReviewApplicationPage /></PrivateRoute> },
   { path: '/calls', element: <PrivateRoute><CallsPage /></PrivateRoute> },
   { path: '/calls/:callId', element: <PrivateRoute><CallDetailPage /></PrivateRoute> },
 


### PR DESCRIPTION
## Summary
- add API helper to download attachments for reviewers
- add ReviewDashboard and ReviewApplicationPage pages for reviewers
- link reviewer dashboard in Navbar and redirect
- register reviewer pages in routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ee74835bc832c880d05887d4d36b9