### PR TITLE
Display role on auth pages

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -11,6 +11,9 @@ export default function LoginPage() {
       <div className="max-w-md mx-auto bg-white p-8 rounded-lg shadow-lg">
         <h1 className="text-2xl font-bold text-center mb-6">Welcome Back</h1>
         {role && (
+          <p className="text-center mb-4 capitalize text-gray-700">Role: {role}</p>
+        )}
+        {role && (
           <LoginForm
             role={role}
             onSuccess={() => navigate(role === 'admin' ? '/admin/calls' : '/calls')}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -10,6 +10,9 @@ export default function RegisterPage() {
       <div className="max-w-md mx-auto bg-white p-8 rounded-lg shadow-lg">
         <h1 className="text-2xl font-bold text-center mb-6">Create Your Account</h1>
         {role && (
+          <p className="text-center mb-4 capitalize text-gray-700">Role: {role}</p>
+        )}
+        {role && (
           <RegisterForm role={role} onSuccess={() => navigate(`/login/${role}`)} />
         )}
       </div>


### PR DESCRIPTION
## Summary
- show active role on login page
- show active role on register page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684eee51ab3c832c8d630055350ef8f1