### PR TITLE
Use snake_case for user names

### DIFF
--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -28,8 +28,8 @@ export interface Attachment {
 export interface User {
   id: number
   email: string
-  firstName?: string
-  lastName?: string
+  first_name?: string
+  last_name?: string
   organization?: string
 }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -5,8 +5,8 @@ export interface RegisterData {
   email: string
   password: string
   role: string
-  firstName?: string
-  lastName?: string
+  first_name?: string
+  last_name?: string
   organization?: string
 }
 

--- a/frontend/src/components/ApplicationCard.tsx
+++ b/frontend/src/components/ApplicationCard.tsx
@@ -67,7 +67,7 @@ export default function ApplicationCard({ application }: Props) {
               <option value="">Select reviewer</option>
               {reviewers.map((r) => (
                 <option key={r.id} value={r.id}>
-                  {r.firstName} {r.lastName}
+                  {r.first_name} {r.last_name}
                 </option>
               ))}
             </select>

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -8,8 +8,8 @@ export interface AuthContextType {
     id: number
     email: string
     role: 'admin' | 'reviewer' | 'applicant'
-    firstName?: string
-    lastName?: string
+    first_name?: string
+    last_name?: string
     organization?: string
   } | null
   role: string | null
@@ -33,8 +33,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           id: decoded.userId,
           email: decoded.email,
           role: decoded.role,
-          firstName: decoded.firstName,
-          lastName: decoded.lastName,
+          first_name: decoded.firstName,
+          last_name: decoded.lastName,
           organization: decoded.organization,
         })
       } catch {
@@ -52,8 +52,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         id: decoded.userId,
         email: decoded.email,
         role: decoded.role,
-        firstName: decoded.firstName,
-        lastName: decoded.lastName,
+        first_name: decoded.firstName,
+        last_name: decoded.lastName,
         organization: decoded.organization,
       })
     } catch {

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -11,8 +11,8 @@ import { Link } from 'react-router-dom'
 const schema = z.object({
   email: z.string().email('Invalid email address'),
   password: z.string().min(6, 'Password must be at least 6 characters'),
-  firstName: z.string().min(1, 'First name is required'),
-  lastName: z.string().min(1, 'Last name is required'),
+  first_name: z.string().min(1, 'First name is required'),
+  last_name: z.string().min(1, 'Last name is required'),
   organization: z.string().min(1, 'Organization is required'),
 })
 
@@ -70,11 +70,13 @@ export default function RegisterForm({ role, onSuccess }: Props) {
         <label htmlFor="first_name" className="block text-sm font-medium text-gray-700">First Name</label>
         <input
           id="first_name"
-          {...register('firstName')}
+          {...register('first_name')}
           disabled={isSubmitting}
           className="mt-1 block w-full border rounded px-4 py-3"
         />
-        {errors.firstName && <p className="text-sm text-red-600">{errors.firstName.message}</p>}
+        {errors.first_name && (
+          <p className="text-sm text-red-600">{errors.first_name.message}</p>
+        )}
       </div>
 
       {/* Last Name */}
@@ -82,11 +84,13 @@ export default function RegisterForm({ role, onSuccess }: Props) {
         <label htmlFor="last_name" className="block text-sm font-medium text-gray-700">Last Name</label>
         <input
           id="last_name"
-          {...register('lastName')}
+          {...register('last_name')}
           disabled={isSubmitting}
           className="mt-1 block w-full border rounded px-4 py-3"
         />
-        {errors.lastName && <p className="text-sm text-red-600">{errors.lastName.message}</p>}
+        {errors.last_name && (
+          <p className="text-sm text-red-600">{errors.last_name.message}</p>
+        )}
       </div>
 
       {/* Organization */}


### PR DESCRIPTION
## Summary
- align `RegisterData` with backend by using `first_name` and `last_name`
- update registration form to send snake_case fields
- read snake_case user info in auth context and application card

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684eee56b644832cadb1d941aebb2a3d