### PR TITLE
Display reviewer names in dropdown

### DIFF
--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -28,8 +28,8 @@ export interface Attachment {
 export interface User {
   id: number
   email: string
-  firstName?: string
-  lastName?: string
+  first_name?: string
+  last_name?: string
   organization?: string
 }
 

--- a/frontend/src/components/ApplicationCard.tsx
+++ b/frontend/src/components/ApplicationCard.tsx
@@ -67,7 +67,7 @@ export default function ApplicationCard({ application }: Props) {
               <option value="">Select reviewer</option>
               {reviewers.map((r) => (
                 <option key={r.id} value={r.id}>
-                  {r.firstName} {r.lastName}
+                  {r.first_name} {r.last_name}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
## Summary
- update `User` type to use `first_name` & `last_name`
- show reviewer names in `ApplicationCard` dropdown using backend fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684eee582c14832c991fbbd246701f3e