### PR TITLE
Show confirmed attachment counts

### DIFF
--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -23,6 +23,7 @@ export interface Attachment {
   id: number
   file_name: string
   document_id: number
+  is_confirmed: boolean
 }
 
 export interface User {

--- a/frontend/src/components/ApplicationCard.tsx
+++ b/frontend/src/components/ApplicationCard.tsx
@@ -34,6 +34,10 @@ export default function ApplicationCard({ application }: Props) {
     }
   }
 
+  const confirmedCount = application.attachments?.filter(a => a.is_confirmed)
+    .length || 0
+  const totalCount = application.attachments?.length || 0
+
   return (
     <li className="border rounded-lg p-4 shadow-sm bg-white space-y-4">
       <div className="space-y-1">
@@ -41,8 +45,14 @@ export default function ApplicationCard({ application }: Props) {
         <h2 className="text-lg font-semibold text-gray-800">{application.user_email}</h2>
         <p className="text-sm text-gray-600">
           Documents Confirmed:{' '}
-          <span className={application.documents_confirmed ? 'text-green-700' : 'text-red-600'}>
-            {application.documents_confirmed ? 'Yes' : 'No'}
+          <span
+            className={
+              confirmedCount === totalCount && totalCount > 0
+                ? 'text-green-700'
+                : 'text-red-600'
+            }
+          >
+            {confirmedCount}/{totalCount}
           </span>
         </p>
       </div>

--- a/frontend/src/pages/admin/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/admin/ApplicationDetailPage.tsx
@@ -33,6 +33,9 @@ export default function ApplicationDetailPage() {
     )
   }
 
+  const confirmedCount = application.attachments?.filter(a => a.is_confirmed).length || 0
+  const totalCount = application.attachments?.length || 0
+
   return (
     <section className="max-w-3xl mx-auto space-y-6 px-4">
       {/* Header */}
@@ -42,8 +45,14 @@ export default function ApplicationDetailPage() {
           <div className="flex items-center gap-2"><span>📧</span><strong>Applicant Email:</strong> {application.user_email}</div>
           <div className="flex items-center gap-2">
             <span>📎</span><strong>Documents Confirmed:</strong>{' '}
-            <span className={`ml-1 px-2 py-0.5 rounded text-white text-sm ${application.documents_confirmed ? 'bg-green-500' : 'bg-red-500'}`}>
-              {application.documents_confirmed ? 'Yes' : 'No'}
+            <span
+              className={`ml-1 px-2 py-0.5 rounded text-white text-sm ${
+                confirmedCount === totalCount && totalCount > 0
+                  ? 'bg-green-500'
+                  : 'bg-red-500'
+              }`}
+            >
+              {confirmedCount}/{totalCount}
             </span>
           </div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- display number of confirmed/total attachments on each application card
- show the same confirmed/total count in the application details page
- keep track of attachment confirmation state in the Attachment interface

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684ef1acd7e0832cbebee8d591af50a8