### PR TITLE
Remove stale viewed by info

### DIFF
--- a/frontend/src/pages/admin/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/admin/ApplicationDetailPage.tsx
@@ -50,7 +50,6 @@ export default function ApplicationDetailPage() {
             <span>📌</span><strong>Status:</strong>{' '}
             <span className="bg-gray-200 text-gray-800 px-2 py-0.5 rounded text-sm">{(application as any).status ?? 'Unknown'}</span>
           </div>
-          <div className="flex items-center gap-2"><span>🧑‍💼</span><strong>Viewed by:</strong> {user?.role ?? 'Unknown'}</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- remove the `Viewed by` line from the application details page

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ef1b2a3d8832c905f91102a8eee96