### PR TITLE
Show applicant data on admin detail

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -76,8 +76,11 @@ def _build_application_detail(db: Session, app: Application) -> ApplicationDetai
         user_id=app.user_id,
         call_id=app.call_id,
         content=app.content,
+        created_at=app.created_at,
         documents_confirmed=attachments_confirmed(db, app.id),
         user_email=app.user.email if app.user else "",
+        user_first_name=app.user.first_name if app.user else None,
+        user_last_name=app.user.last_name if app.user else None,
         attachments=get_attachments_by_application(db, app.id),
         reviewers=[
             ReviewerShort(id=r.user.id, name=f"{r.user.first_name} {r.user.last_name}")

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -35,6 +35,9 @@ class ApplicationDetail(BaseModel):
     content: str
     documents_confirmed: bool   # Whether the user confirmed their documents
     user_email: str      # Pulled from the User table via JOIN
+    user_first_name: str | None = None
+    user_last_name: str | None = None
+    created_at: datetime
     attachments: list[AttachmentOut]  # List of uploaded documents
     reviewers: list[ReviewerShort]
 

--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -35,6 +35,9 @@ export interface User {
 
 export interface ApplicationDetail extends Application {
   user_email: string
+  user_first_name?: string
+  user_last_name?: string
+  created_at: string
   documents_confirmed: boolean
   attachments: Attachment[]
   reviewers?: User[]

--- a/frontend/src/pages/admin/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/admin/ApplicationDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { fetchApplicationDetails, downloadAttachment } from '../../api'
-import type { ApplicationDetail, Attachment } from '../../api'
+import { fetchApplicationDetails, downloadAttachment, fetchCall } from '../../api'
+import type { ApplicationDetail, Attachment, Call } from '../../api'
 import { downloadBlob } from '../../lib/download'
 import { useToast } from '../../components/ToastProvider'
 import { useAuth } from '../../components/AuthProvider'
@@ -10,14 +10,21 @@ import { FileIcon, DownloadIcon } from 'lucide-react'
 export default function ApplicationDetailPage() {
   const { applicationId } = useParams<{ applicationId: string }>()
   const [application, setApplication] = useState<ApplicationDetail | null>(null)
+  const [call, setCall] = useState<Call | null>(null)
   const { user } = useAuth()
   const { showToast } = useToast()
 
   useEffect(() => {
     if (!applicationId) return
     fetchApplicationDetails(Number(applicationId))
-      .then(setApplication)
-      .catch(() => setApplication(null))
+      .then(app => {
+        setApplication(app)
+        fetchCall(app.call_id).then(setCall).catch(() => setCall(null))
+      })
+      .catch(() => {
+        setApplication(null)
+        setCall(null)
+      })
   }, [applicationId])
 
   const getReadableFileName = (filename: string) => {
@@ -39,13 +46,31 @@ export default function ApplicationDetailPage() {
       <div className="border rounded-xl p-6 shadow bg-white space-y-3">
         <h1 className="text-2xl font-bold text-gray-800">Application #{application.id}</h1>
         <div className="space-y-1 text-gray-700">
-          <div className="flex items-center gap-2"><span>📧</span><strong>Applicant Email:</strong> {application.user_email}</div>
+          <div className="flex items-center gap-2">
+            <span>🧑</span>
+            <strong>Applicant:</strong>{' '}
+            {application.user_first_name} {application.user_last_name} ({application.user_email})
+          </div>
+          <div className="flex items-center gap-2">
+            <span>🗓️</span>
+            <strong>Submitted:</strong>{' '}
+            {new Date(application.created_at).toLocaleDateString()}
+          </div>
           <div className="flex items-center gap-2">
             <span>📎</span><strong>Documents Confirmed:</strong>{' '}
             <span className={`ml-1 px-2 py-0.5 rounded text-white text-sm ${application.documents_confirmed ? 'bg-green-500' : 'bg-red-500'}`}>
               {application.documents_confirmed ? 'Yes' : 'No'}
             </span>
           </div>
+          {call && (
+            <div className="flex items-center gap-2">
+              <span>📅</span>
+              <strong>Call:</strong>{' '}
+              {call.start_date ? new Date(call.start_date).toLocaleDateString() : 'N/A'}
+              {' - '}
+              {call.end_date ? new Date(call.end_date).toLocaleDateString() : 'N/A'}
+            </div>
+          )}
           <div className="flex items-center gap-2">
             <span>📌</span><strong>Status:</strong>{' '}
             <span className="bg-gray-200 text-gray-800 px-2 py-0.5 rounded text-sm">{(application as any).status ?? 'Unknown'}</span>


### PR DESCRIPTION
## Summary
- include applicant name and creation date in `ApplicationDetail`
- expose the new fields from CRUD helper
- extend TypeScript interfaces for the extra information
- display applicant name, submission date and call dates on the detail page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ef1b8f3fc832cb3780194012bf021