### PR TITLE
Fix ConfirmModal description semantics

### DIFF
--- a/frontend/src/components/ui/ConfirmModal.tsx
+++ b/frontend/src/components/ui/ConfirmModal.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle
@@ -36,9 +37,11 @@ export function ConfirmModal({
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
-        <div className="py-2 text-sm text-muted-foreground">
-          {description}
-        </div>
+        {description && (
+          <DialogDescription className="py-2">
+            {description}
+          </DialogDescription>
+        )}
         <DialogFooter className="gap-2 justify-center">
           <Button variant="outline" onClick={onClose}>{cancelLabel}</Button>
           <Button


### PR DESCRIPTION
## Summary
- fix accessibility in ConfirmModal by using `<DialogDescription>`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f05dbf4fc832c80dd6e9f0aa1bcd6