### PR TITLE
Fix duplicate review download helper

### DIFF
--- a/frontend/src/api/review.ts
+++ b/frontend/src/api/review.ts
@@ -65,17 +65,3 @@ export async function deleteReview(id: number): Promise<void> {
   })
   if (!res.ok) throw new Error('Failed to delete review')
 }
-
-// Reviewer downloads an attachment for review
-export async function downloadAttachmentForReview(
-  attachmentId: number
-): Promise<Blob> {
-  const res = await fetch(
-    `${API_BASE}/attachments/${attachmentId}/download`,
-    {
-      headers: { ...authHeaders() },
-    }
-  )
-  if (!res.ok) throw new Error('Failed to download attachment')
-  return res.blob()
-}


### PR DESCRIPTION
## Summary
- remove the duplicate `downloadAttachmentForReview` definition from `review.ts`
- rely on the version exported from `application.ts`

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f062e54f8832c90a8ae9642e9ad32