### PR TITLE
Support multiple reviewers and improve call deletion error

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -113,21 +113,31 @@ def get_application_detail(db: Session, application_id: int) -> ApplicationDetai
 
 
 def assign_reviewer(db: Session, application_id: int, reviewer_id: int) -> Application:
-    """Assign a reviewer to an application with many-to-many support."""
+    """Assign a reviewer to an application with many-to-many support.
+
+    Ensures no more than 3 distinct reviewers are assigned to a single
+    application and prevents duplicate assignments.
+    """
+
     application = db.query(Application).filter(Application.id == application_id).first()
     if not application:
         raise ValueError("Application not found")
 
-    # Duplicate kontrolü
+    # Check existing assignments
     existing = db.query(ApplicationReviewer).filter_by(
         application_id=application_id, user_id=reviewer_id
     ).first()
+    if existing:
+        raise ValueError("Reviewer already assigned")
 
-    if not existing:
-        assignment = ApplicationReviewer(application_id=application_id, user_id=reviewer_id)
-        db.add(assignment)
-        db.commit()
-        
+    count = db.query(ApplicationReviewer).filter_by(application_id=application_id).count()
+    if count >= 3:
+        raise ValueError("Maximum number of reviewers reached")
+
+    assignment = ApplicationReviewer(application_id=application_id, user_id=reviewer_id)
+    db.add(assignment)
+    db.commit()
+
     db.refresh(application)
     return application
 

--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -198,7 +198,10 @@ export async function assignReviewer(applicationId: number, reviewerId: number):
       },
     }
   )
-  if (!res.ok) throw new Error('Failed to assign reviewer')
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.detail || 'Failed to assign reviewer')
+  }
 }
 
 // 11. Hakem listesini getir (admin için)

--- a/frontend/src/api/call.ts
+++ b/frontend/src/api/call.ts
@@ -36,5 +36,8 @@ export async function updateCall(id: number, data: CallInput): Promise<Call> {
 
 export async function deleteCall(id: number): Promise<void> {
   const res = await fetch(`${API_BASE}/calls/${id}`, { method:'DELETE', headers: authHeaders() })
-  if (!res.ok) throw new Error('Failed to delete call')
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.detail || 'Failed to delete call')
+  }
 }

--- a/frontend/src/components/ApplicationCard.tsx
+++ b/frontend/src/components/ApplicationCard.tsx
@@ -11,6 +11,7 @@ interface Props {
 
 export default function ApplicationCard({ application }: Props) {
   const [reviewers, setReviewers] = useState<User[]>([])
+  const [assigned, setAssigned] = useState<User[]>(application.reviewers || [])
   const [selectedReviewerId, setSelectedReviewerId] = useState<number | null>(null)
   const [assigning, setAssigning] = useState(false)
   const { showToast } = useToast()
@@ -23,14 +24,22 @@ export default function ApplicationCard({ application }: Props) {
     }
   }, [isAdmin])
 
+  useEffect(() => {
+    setAssigned(application.reviewers || [])
+  }, [application.reviewers])
+
   const handleAssign = async () => {
     if (!selectedReviewerId) return
     setAssigning(true)
     try {
       await assignReviewer(application.id, selectedReviewerId)
+      const newReviewer = reviewers.find(r => r.id === selectedReviewerId)
+      if (newReviewer) {
+        setAssigned(prev => [...prev, newReviewer])
+      }
       showToast('Reviewer assigned successfully', 'success')
-    } catch {
-      showToast('Failed to assign reviewer', 'error')
+    } catch (e: any) {
+      showToast(e.message || 'Failed to assign reviewer', 'error')
     } finally {
       setAssigning(false)
     }
@@ -70,27 +79,42 @@ export default function ApplicationCard({ application }: Props) {
 
       {isAdmin && (
         <div className="space-y-2">
-          <p className="text-sm font-medium">Assign Reviewer:</p>
-          <div className="flex gap-2 items-center">
-            <select
-              className="border rounded px-2 py-1 text-sm"
-              onChange={(e) => setSelectedReviewerId(Number(e.target.value))}
-            >
-              <option value="">Select reviewer</option>
-              {reviewers.map((r) => (
-                <option key={r.id} value={r.id}>
-                  {r.first_name} {r.last_name}
-                </option>
+          <p className="text-sm font-medium">Assigned Reviewers:</p>
+          {assigned.length > 0 ? (
+            <ul className="list-disc ml-5 text-sm space-y-1">
+              {assigned.map(r => (
+                <li key={r.id}>{r.first_name} {r.last_name}</li>
               ))}
-            </select>
-            <button
-              onClick={handleAssign}
-              className="bg-blue-600 text-white text-sm px-3 py-1 rounded hover:bg-blue-700 transition"
-              disabled={assigning || !selectedReviewerId}
-            >
-              {assigning ? 'Assigning...' : 'Assign'}
-            </button>
-          </div>
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-500">None</p>
+          )}
+
+          {assigned.length < 3 && (
+            <div className="flex gap-2 items-center pt-2">
+              <select
+                className="border rounded px-2 py-1 text-sm"
+                onChange={e => setSelectedReviewerId(Number(e.target.value))}
+                value={selectedReviewerId ?? ''}
+              >
+                <option value="">Select reviewer</option>
+                {reviewers
+                  .filter(r => !assigned.some(a => a.id === r.id))
+                  .map(r => (
+                    <option key={r.id} value={r.id}>
+                      {r.first_name} {r.last_name}
+                    </option>
+                  ))}
+              </select>
+              <button
+                onClick={handleAssign}
+                className="bg-blue-600 text-white text-sm px-3 py-1 rounded hover:bg-blue-700 transition"
+                disabled={assigning || !selectedReviewerId}
+              >
+                {assigning ? 'Assigning...' : 'Assign'}
+              </button>
+            </div>
+          )}
         </div>
       )}
     </li>

--- a/frontend/src/pages/admin/CallManagementPage.tsx
+++ b/frontend/src/pages/admin/CallManagementPage.tsx
@@ -89,8 +89,8 @@ export default function CallManagementPage() {
       await deleteCall(pendingDeleteId)
       showToast('Call deleted', 'success')
       setCalls(prev => prev.filter(c => c.id !== pendingDeleteId))
-    } catch {
-      showToast('Failed to delete call', 'error')
+    } catch (e: any) {
+      showToast(e.message || 'Failed to delete call', 'error')
     } finally {
       setDeletingId(null)
       setPendingDeleteId(null)


### PR DESCRIPTION
## Summary
- allow up to three distinct reviewers for an application on the backend
- expose server error messages from call deletion and reviewer assignment
- display assigned reviewers in admin application card
- show server error when deleting a call fails

## Testing
- `pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684f2a86e13c832c86572f4507178dcd