### PR TITLE
Update application detail to return user object

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -78,9 +78,7 @@ def _build_application_detail(db: Session, app: Application) -> ApplicationDetai
         content=app.content,
         created_at=app.created_at,
         documents_confirmed=attachments_confirmed(db, app.id),
-        user_email=app.user.email if app.user else "",
-        user_first_name=app.user.first_name if app.user else None,
-        user_last_name=app.user.last_name if app.user else None,
+        user=app.user,
         attachments=get_attachments_by_application(db, app.id),
         reviewers=[
             ReviewerShort(id=r.user.id, name=f"{r.user.first_name} {r.user.last_name}")

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict
 from .attachment import AttachmentOut
+from .user import UserOut
 from datetime import datetime
 
 
@@ -34,9 +35,7 @@ class ApplicationDetail(BaseModel):
     call_id: int
     content: str
     documents_confirmed: bool   # Whether the user confirmed their documents
-    user_email: str      # Pulled from the User table via JOIN
-    user_first_name: str | None = None
-    user_last_name: str | None = None
+    user: UserOut
     created_at: datetime
     attachments: list[AttachmentOut]  # List of uploaded documents
     reviewers: list[ReviewerShort]

--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -35,9 +35,7 @@ export interface User {
 }
 
 export interface ApplicationDetail extends Application {
-  user_email: string
-  user_first_name?: string
-  user_last_name?: string
+  user: User
   created_at: string
   documents_confirmed: boolean
   attachments: Attachment[]

--- a/frontend/src/components/ApplicationCard.tsx
+++ b/frontend/src/components/ApplicationCard.tsx
@@ -44,7 +44,7 @@ export default function ApplicationCard({ application }: Props) {
     <li className="border rounded-lg p-4 shadow-sm bg-white space-y-4">
       <div className="space-y-1">
         <p className="text-sm text-gray-500">Application ID: {application.id}</p>
-        <h2 className="text-lg font-semibold text-gray-800">{application.user_email}</h2>
+        <h2 className="text-lg font-semibold text-gray-800">{application.user.email}</h2>
         <p className="text-sm text-gray-600">
           Documents Confirmed:{' '}
           <span

--- a/frontend/src/components/ApplicationList.tsx
+++ b/frontend/src/components/ApplicationList.tsx
@@ -59,7 +59,7 @@ export default function ApplicationList({ callId }: Props) {
         <ul className="space-y-4">
           {filtered.map((app) => (
             <li key={app.id} className="border p-4 rounded shadow">
-              <p className="font-semibold">{app.user_email}</p>
+              <p className="font-semibold">{app.user.email}</p>
               <p>Status: {app.documents_confirmed ? 'Submitted' : 'In Progress'}</p>
               {app.attachments.length > 0 && (
                 <ul className="list-disc pl-5">

--- a/frontend/src/pages/admin/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/admin/ApplicationDetailPage.tsx
@@ -57,7 +57,7 @@ export default function ApplicationDetailPage() {
           <div className="flex items-center gap-2">
             <span>🧑</span>
             <strong>Applicant:</strong>{' '}
-            {application.user_first_name} {application.user_last_name} ({application.user_email})
+            {application.user.first_name} {application.user.last_name} ({application.user.email})
           </div>
           <div className="flex items-center gap-2">
             <span>🗓️</span>

--- a/frontend/src/pages/reviewer/ReviewApplicationPage.tsx
+++ b/frontend/src/pages/reviewer/ReviewApplicationPage.tsx
@@ -82,7 +82,7 @@ export default function ReviewApplicationPage() {
 
       <div className="space-y-1">
         <p>
-          <strong>Applicant:</strong> {application.user_email}
+          <strong>Applicant:</strong> {application.user.email}
         </p>
         <p>
           <strong>Documents Confirmed:</strong>{' '}

--- a/frontend/src/pages/reviewer/ReviewDashboard.tsx
+++ b/frontend/src/pages/reviewer/ReviewDashboard.tsx
@@ -74,7 +74,7 @@ export default function ReviewDashboard() {
     .filter(
       a =>
         a.callTitle.toLowerCase().includes(search.toLowerCase()) ||
-        a.user_email.toLowerCase().includes(search.toLowerCase())
+        a.user.email.toLowerCase().includes(search.toLowerCase())
     )
 
   return (
@@ -114,11 +114,11 @@ export default function ReviewDashboard() {
               <TableRow key={app.id} className={idx % 2 ? 'bg-gray-50' : ''}>
                 <TableCell>{app.callTitle}</TableCell>
                 <TableCell>
-                  {app.user_first_name || app.user_last_name
-                    ? `${app.user_first_name ?? ''} ${app.user_last_name ?? ''}`.trim()
+                  {app.user.first_name || app.user.last_name
+                    ? `${app.user.first_name ?? ''} ${app.user.last_name ?? ''}`.trim()
                     : '-'}
                 </TableCell>
-                <TableCell>{app.user_email}</TableCell>
+                <TableCell>{app.user.email}</TableCell>
                 <TableCell>
                   {app.created_at ? format(new Date(app.created_at), 'yyyy-MM-dd') : '-'}
                 </TableCell>


### PR DESCRIPTION
## Summary
- replace separate user fields in ApplicationDetail with `user`
- adjust application CRUD to populate new schema
- update ApplicationDetail interface in frontend
- use `application.user` in admin and reviewer pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f2e011acc832cb9112cac236ecd3a