### PR TITLE
Add reviewer invite token API

### DIFF
--- a/backend/app/crud/reviewer_invite.py
+++ b/backend/app/crud/reviewer_invite.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from sqlalchemy.orm import Session
+
+from ..models.reviewer_invite_token import ReviewerInviteToken
+
+
+def create_invite(db: Session, call_id: int, token: str, expires_at: datetime) -> ReviewerInviteToken:
+    invite = ReviewerInviteToken(call_id=call_id, token=token, expires_at=expires_at)
+    db.add(invite)
+    db.commit()
+    db.refresh(invite)
+    return invite

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from .routes import (
     user_router,
     auth_router,
     review_router,
+    reviewer_invite_router,
 )
 
 # Configure root logger
@@ -93,3 +94,4 @@ app.include_router(call_router)
 app.include_router(application_router)
 app.include_router(document_router)
 app.include_router(review_router)
+app.include_router(reviewer_invite_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,6 +10,7 @@ from .attachment import Attachment  # noqa: F401
 from .document import DocumentDefinition  # noqa: F401
 from .application_reviewer import ApplicationReviewer  # noqa: F401
 from .review import Review
+from .reviewer_invite_token import ReviewerInviteToken  # noqa: F401
 
 __all__ = [
     "Base",
@@ -20,4 +21,5 @@ __all__ = [
     "DocumentDefinition",
     "ApplicationReviewer",
     "Review",
+    "ReviewerInviteToken",
 ]

--- a/backend/app/models/reviewer_invite_token.py
+++ b/backend/app/models/reviewer_invite_token.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+class ReviewerInviteToken(Base):
+    __tablename__ = "reviewer_invite_tokens"
+
+    id = Column(Integer, primary_key=True)
+    call_id = Column(Integer, ForeignKey("calls.id"), nullable=False)
+    token = Column(String(6), unique=True, index=True, nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    call = relationship("Call")

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -3,6 +3,7 @@ from .calls import router as call_router
 from .documents import router as document_router
 from .users import router as user_router, auth_router, list_reviewers
 from .review import router as review_router
+from .reviewer_invites import router as reviewer_invite_router
 
 __all__ = [
     "application_router",
@@ -12,4 +13,5 @@ __all__ = [
     "list_reviewers",
     "auth_router",
     "review_router",
+    "reviewer_invite_router",
 ]

--- a/backend/app/routes/reviewer_invites.py
+++ b/backend/app/routes/reviewer_invites.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+import secrets
+import string
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from ..dependencies import get_current_admin
+from ..models.call import Call
+from ..schemas.reviewer_invite import ReviewerInviteCreate, ReviewerInviteTokenOut
+from ..crud.reviewer_invite import create_invite
+
+router = APIRouter(prefix="/reviewer/invites", tags=["reviewers"])
+
+
+@router.post("/generate", response_model=ReviewerInviteTokenOut, status_code=status.HTTP_201_CREATED)
+def generate_invite(
+    data: ReviewerInviteCreate,
+    db: Session = Depends(get_db),
+    current_admin = Depends(get_current_admin),
+):
+    call = db.query(Call).filter(Call.id == data.call_id).first()
+    if not call:
+        raise HTTPException(status_code=404, detail="Call not found")
+
+    token_chars = string.ascii_uppercase + string.digits
+    token = "".join(secrets.choice(token_chars) for _ in range(6))
+
+    hours = data.expiration_hours or 24
+    expires_at = datetime.utcnow() + timedelta(hours=hours)
+
+    invite = create_invite(db, call_id=data.call_id, token=token, expires_at=expires_at)
+    return invite

--- a/backend/app/schemas/reviewer_invite.py
+++ b/backend/app/schemas/reviewer_invite.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+class ReviewerInviteCreate(BaseModel):
+    call_id: int
+    expiration_hours: int | None = None
+
+class ReviewerInviteTokenOut(BaseModel):
+    id: int
+    call_id: int
+    token: str
+    expires_at: datetime
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- create ReviewerInviteToken model and schemas
- add `/reviewer/invites/generate` endpoint
- register reviewer invite router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f3c906494832ca75d72ffeccda9e9