### PR TITLE
Add reviewer invite linking page

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,3 +5,17 @@ export * from './application'
 export * from './call'
 export * from './document'
 export * from './review'
+import { API_BASE } from './config'
+import { authHeaders } from './auth'
+
+export async function acceptReviewerInvite(code: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/reviewer/invites/accept`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ code }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.detail || 'Failed to accept invite')
+  }
+}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -13,7 +13,12 @@ export default function RegisterPage() {
           <p className="text-center mb-4 capitalize text-gray-700">Role: {role}</p>
         )}
         {role && (
-          <RegisterForm role={role} onSuccess={() => navigate(`/login/${role}`)} />
+          <RegisterForm
+            role={role}
+            onSuccess={() =>
+              navigate(role === 'reviewer' ? '/reviewer/link' : `/login/${role}`)
+            }
+          />
         )}
       </div>
     </section>

--- a/frontend/src/pages/reviewer/ReviewerLinkPage.tsx
+++ b/frontend/src/pages/reviewer/ReviewerLinkPage.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { acceptReviewerInvite } from '../../api'
+import { useToast } from '../../components/ToastProvider'
+
+export default function ReviewerLinkPage() {
+  const [code, setCode] = useState('')
+  const [loading, setLoading] = useState(false)
+  const { showToast } = useToast()
+  const navigate = useNavigate()
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      await acceptReviewerInvite(code)
+      showToast('Invite accepted! You can now log in.', 'success')
+      navigate('/login/reviewer')
+    } catch (err: any) {
+      showToast(err?.message || 'Failed to accept invite', 'error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="w-full bg-gray-50 py-16 px-4">
+      <div className="max-w-md mx-auto bg-white p-8 rounded-lg shadow-lg space-y-4">
+        <h1 className="text-2xl font-bold text-center">Link Reviewer Account</h1>
+        <form onSubmit={submit} className="space-y-4">
+          <input
+            type="text"
+            value={code}
+            onChange={e => setCode(e.target.value)}
+            placeholder="Invite Code"
+            className="w-full border rounded p-2"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? 'Submitting...' : 'Submit'}
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -27,6 +27,7 @@ const CallDocumentsPage = React.lazy(() => import('./pages/admin/CallDocumentsPa
 const CallApplicationsPage = React.lazy(() => import('./pages/reviewer/CallApplicationsPage'))
 const ReviewDashboard = React.lazy(() => import('./pages/reviewer/ReviewDashboard'))
 const ReviewApplicationPage = React.lazy(() => import('./pages/reviewer/ReviewApplicationPage'))
+const ReviewerLinkPage = React.lazy(() => import('./pages/reviewer/ReviewerLinkPage'))
 const ApplicationDetailPage = React.lazy(() => import('./pages/admin/ApplicationDetailPage'))
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage'))
 
@@ -39,6 +40,7 @@ export const appRoutes = [
   { path: '/register', element: <Navigate to="/auth" replace /> },
   { path: '/login/:role', element: <LoginPage /> },
   { path: '/login', element: <Navigate to="/auth" replace /> },
+  { path: '/reviewer/link', element: <ReviewerLinkPage /> },
   { path: '/verify/:token', element: <VerifyEmailPage /> },
   { path: '/password-reset', element: <PasswordResetRequestPage /> },
   { path: '/password-reset/:token', element: <PasswordResetConfirmPage /> },


### PR DESCRIPTION
## Summary
- add API helper to accept reviewer invite
- create `ReviewerLinkPage` for entering invite code
- redirect reviewer sign-ups to invitation link page
- register new `/reviewer/link` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f3c92a974832ca94b0327ff524264