### PR TITLE
Add ReviewerInviteToken model

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,7 +9,8 @@ from .application import Application  # noqa: F401
 from .attachment import Attachment  # noqa: F401
 from .document import DocumentDefinition  # noqa: F401
 from .application_reviewer import ApplicationReviewer  # noqa: F401
-from .review import Review
+from .review import Review  # noqa: F401
+from .reviewer_invite_token import ReviewerInviteToken  # noqa: F401
 
 __all__ = [
     "Base",
@@ -20,4 +21,5 @@ __all__ = [
     "DocumentDefinition",
     "ApplicationReviewer",
     "Review",
+    "ReviewerInviteToken",
 ]

--- a/backend/app/models/reviewer_invite_token.py
+++ b/backend/app/models/reviewer_invite_token.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Boolean, DateTime
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+
+class ReviewerInviteToken(Base):
+    __tablename__ = "reviewer_invite_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String(6), unique=True, nullable=False)
+    call_id = Column(Integer, ForeignKey("calls.id"), nullable=False)
+    is_used = Column(Boolean, nullable=False, default=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)


### PR DESCRIPTION
## Summary
- create ORM model `ReviewerInviteToken`
- export it from the models package
- remove Alembic migration scaffolding

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f3c8f3f28832cad6d3df66a7603ec