### PR TITLE
Fix reviewer token Boolean import

### DIFF
--- a/backend/app/models/reviewer_invite_token.py
+++ b/backend/app/models/reviewer_invite_token.py
@@ -1,5 +1,5 @@
 
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Boolean
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 


### PR DESCRIPTION
## Summary
- add missing Boolean type to ReviewerInviteToken model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f42e00098832c9c4c46e4409859ab