### PR TITLE
Add ReviewerInviteToken to models init

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from .application_reviewer import ApplicationReviewer  # noqa: F401
 from .review import Review
 from .reviewer_invite import ReviewerInvite  # noqa: F401
 from .call_reviewer import CallReviewer  # noqa: F401
+from .reviewer_invite_token import ReviewerInviteToken  # noqa: F401
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- import `ReviewerInviteToken`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f42ea00a8832cba6f78f83580ae9c