### PR TITLE
Consolidate reviewer invite router

### DIFF
--- a/backend/app/routes/reviewer_invites.py
+++ b/backend/app/routes/reviewer_invites.py
@@ -5,37 +5,51 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
-from ..dependencies import get_current_user
+from ..dependencies import get_current_user, get_current_admin
 from ..models.user import UserRole
-from ..crud.reviewer_invite import get_invite_by_token, accept_invite
+from ..models.call import Call
+from ..schemas.reviewer_invite import ReviewerInviteCreate, ReviewerInviteTokenOut
+from ..crud.reviewer_invite import (
+    get_invite_by_token,
+    accept_invite,
+    create_invite,
+)
 
 router = APIRouter(prefix="/reviewer/invites", tags=["reviewer_invites"])
 
 
 @router.post("/accept")
-def accept_reviewer_invite(token: str, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+def accept_reviewer_invite(
+    token: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
     if current_user.role is not UserRole.REVIEWER:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only reviewers can accept invites")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only reviewers can accept invites",
+        )
 
     invite = get_invite_by_token(db, token)
     if not invite:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invalid invite token")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invalid invite token",
+        )
 
     accept_invite(db, invite, current_user.id)
     return {"detail": "Invite accepted"}
-from ..dependencies import get_current_admin
-from ..models.call import Call
-from ..schemas.reviewer_invite import ReviewerInviteCreate, ReviewerInviteTokenOut
-from ..crud.reviewer_invite import create_invite
-
-router = APIRouter(prefix="/reviewer/invites", tags=["reviewers"])
 
 
-@router.post("/generate", response_model=ReviewerInviteTokenOut, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/generate",
+    response_model=ReviewerInviteTokenOut,
+    status_code=status.HTTP_201_CREATED,
+)
 def generate_invite(
     data: ReviewerInviteCreate,
     db: Session = Depends(get_db),
-    current_admin = Depends(get_current_admin),
+    current_admin=Depends(get_current_admin),
 ):
     call = db.query(Call).filter(Call.id == data.call_id).first()
     if not call:
@@ -47,5 +61,10 @@ def generate_invite(
     hours = data.expiration_hours or 24
     expires_at = datetime.utcnow() + timedelta(hours=hours)
 
-    invite = create_invite(db, call_id=data.call_id, token=token, expires_at=expires_at)
+    invite = create_invite(
+        db,
+        call_id=data.call_id,
+        token=token,
+        expires_at=expires_at,
+    )
     return invite


### PR DESCRIPTION
## Summary
- refactor `reviewer_invites.py` so there is only one `APIRouter`
- keep `/accept` and `/generate` endpoints on the same router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f42f1ba64832c912da524ce2595ed