### PR TITLE
Add status field to ApplicationDetail

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -76,6 +76,7 @@ def _build_application_detail(db: Session, app: Application) -> ApplicationDetai
         user_id=app.user_id,
         call_id=app.call_id,
         content=app.content,
+        status=app.status,
         created_at=app.created_at,
         documents_confirmed=attachments_confirmed(db, app.id),
         user=app.user,

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -34,6 +34,7 @@ class ApplicationDetail(BaseModel):
     user_id: int
     call_id: int
     content: str
+    status: str
     documents_confirmed: bool   # Whether the user confirmed their documents
     user: UserOut
     created_at: datetime


### PR DESCRIPTION
## Summary
- include a `status` attribute in `ApplicationDetail` schema
- populate `status` from the model in `_build_application_detail`

## Testing
- `pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f42f620e0832c95b8100299dbd19c