### PR TITLE
Align reviewer schema with frontend

### DIFF
--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -81,7 +81,11 @@ def _build_application_detail(db: Session, app: Application) -> ApplicationDetai
         user=app.user,
         attachments=get_attachments_by_application(db, app.id),
         reviewers=[
-            ReviewerShort(id=r.user.id, name=f"{r.user.first_name} {r.user.last_name}")
+            ReviewerShort(
+                id=r.user.id,
+                first_name=r.user.first_name,
+                last_name=r.user.last_name,
+            )
             for r in getattr(app, "review_assignments", [])
             if r.user
         ],

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -25,7 +25,9 @@ class ApplicationOut(BaseModel):
 
 class ReviewerShort(BaseModel):
     id: int
-    name: str  # veya email
+    first_name: str | None = None
+    last_name: str | None = None
+
     model_config = ConfigDict(from_attributes=True)
 
 # Detailed schema for one application with user and attachment info

--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -34,12 +34,18 @@ export interface User {
   organization?: string
 }
 
+export interface ReviewerShort {
+  id: number
+  first_name?: string
+  last_name?: string
+}
+
 export interface ApplicationDetail extends Application {
   user: User
   created_at: string
   documents_confirmed: boolean
   attachments: Attachment[]
-  reviewers?: User[]
+  reviewers?: ReviewerShort[]
 }
 
 // 1. Başvuru oluştur

--- a/frontend/src/components/ApplicationCard.tsx
+++ b/frontend/src/components/ApplicationCard.tsx
@@ -1,4 +1,4 @@
-import type { ApplicationDetail, User } from '../api'
+import type { ApplicationDetail, User, ReviewerShort } from '../api'
 import { assignReviewer, fetchReviewers } from '../api'
 import { useEffect, useState } from 'react'
 import { useToast } from './ToastProvider'
@@ -11,7 +11,7 @@ interface Props {
 
 export default function ApplicationCard({ application }: Props) {
   const [reviewers, setReviewers] = useState<User[]>([])
-  const [assigned, setAssigned] = useState<User[]>(application.reviewers || [])
+  const [assigned, setAssigned] = useState<ReviewerShort[]>(application.reviewers || [])
   const [selectedReviewerId, setSelectedReviewerId] = useState<number | null>(null)
   const [assigning, setAssigning] = useState(false)
   const { showToast } = useToast()
@@ -35,7 +35,12 @@ export default function ApplicationCard({ application }: Props) {
       await assignReviewer(application.id, selectedReviewerId)
       const newReviewer = reviewers.find(r => r.id === selectedReviewerId)
       if (newReviewer) {
-        setAssigned(prev => [...prev, newReviewer])
+        const short: ReviewerShort = {
+          id: newReviewer.id,
+          first_name: newReviewer.first_name,
+          last_name: newReviewer.last_name,
+        }
+        setAssigned(prev => [...prev, short])
       }
       showToast('Reviewer assigned successfully', 'success')
     } catch (e: any) {

--- a/frontend/src/pages/reviewer/CallApplicationsPage.tsx
+++ b/frontend/src/pages/reviewer/CallApplicationsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { fetchApplications } from '../../api'
-import type { ApplicationDetail, User } from '../../api'
+import type { ApplicationDetail, User, ReviewerShort } from '../../api'
 import ApplicationCard from '../../components/ApplicationCard'
 import { Input } from '../../components/ui/Input'
 import { Select } from '../../components/ui/Select'
@@ -27,7 +27,7 @@ export default function CallApplicationsPage() {
           if (!token) return
           const myId = JSON.parse(atob(token.split('.')[1])).sub
           const filtered = apps.filter((app) =>
-            app.reviewers?.some((r: User) => r.id == myId)
+            app.reviewers?.some((r: ReviewerShort) => r.id == myId)
           )
           setApplications(filtered)
           setFiltered(filtered)

--- a/frontend/src/pages/reviewer/ReviewDashboard.tsx
+++ b/frontend/src/pages/reviewer/ReviewDashboard.tsx
@@ -9,6 +9,7 @@ import {
   type ApplicationDetail,
   type ReviewOut,
   type User,
+  type ReviewerShort,
 } from '../../api'
 import { useToast } from '../../components/ToastProvider'
 import {
@@ -49,7 +50,7 @@ export default function ReviewDashboard() {
           try {
             const list = await fetchApplications(call.id)
             list.forEach(app => {
-              if (app.reviewers?.some((r: User) => r.id == myId)) {
+              if (app.reviewers?.some((r: ReviewerShort) => r.id == myId)) {
                 results.push({ ...app, callTitle: call.title })
               }
             })


### PR DESCRIPTION
## Summary
- include `first_name` and `last_name` in `ReviewerShort`
- supply reviewer names in `_build_application_detail`
- expose new reviewer shape to the frontend API
- adapt React components and pages for new `ReviewerShort` type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f42fd6f3c832c888f8b23bc2750ed