### PR TITLE
Add shared file name helper

### DIFF
--- a/frontend/src/components/ApplicationList.tsx
+++ b/frontend/src/components/ApplicationList.tsx
@@ -6,6 +6,7 @@ import {
 } from '../api';
 import { useToast } from './ToastProvider';
 import { downloadBlob } from '../lib/download';
+import { getDisplayFileName } from '../lib/file';
 
 interface Props {
   callId: number;
@@ -76,7 +77,7 @@ export default function ApplicationList({ callId }: Props) {
                         }}
                         className="text-blue-600 underline"
                       >
-                        {att.file_name}
+                        {getDisplayFileName(att.file_name)}
                       </button>
                     </li>
                   ))}

--- a/frontend/src/components/AttachmentList.tsx
+++ b/frontend/src/components/AttachmentList.tsx
@@ -1,6 +1,7 @@
 import type { Attachment } from '../api'
 import { downloadAttachmentForReview } from '../api'
 import { downloadBlob } from '../lib/download'
+import { getDisplayFileName } from '../lib/file'
 
 
 interface Props {
@@ -23,7 +24,7 @@ export default function AttachmentList({ attachments }: Props) {
             }}
             className="text-blue-600 underline"
           >
-            {a.file_name}
+            {getDisplayFileName(a.file_name)}
           </button>
         </li>
       ))}

--- a/frontend/src/lib/file.ts
+++ b/frontend/src/lib/file.ts
@@ -1,0 +1,5 @@
+export function getDisplayFileName(filename: string): string {
+  const index = filename.indexOf('_')
+  return index === -1 ? filename : filename.slice(index + 1)
+}
+

--- a/frontend/src/pages/admin/ApplicationDetailPage.tsx
+++ b/frontend/src/pages/admin/ApplicationDetailPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../api'
 import type { ApplicationDetail, Attachment, Call } from '../../api'
 import { downloadBlob } from '../../lib/download'
+import { getDisplayFileName } from '../../lib/file'
 import { useToast } from '../../components/ToastProvider'
 import { useAuth } from '../../components/AuthProvider'
 import { FileIcon, DownloadIcon } from 'lucide-react'
@@ -32,10 +33,6 @@ export default function ApplicationDetailPage() {
       })
   }, [applicationId])
 
-  const getReadableFileName = (filename: string) => {
-    const parts = filename.split('_')
-    return parts.slice(-1)[0] ?? filename
-  }
 
   if (!application) {
     return (
@@ -104,7 +101,7 @@ export default function ApplicationDetailPage() {
               >
                 <div className="flex items-center gap-3 text-sm text-gray-700 truncate max-w-xs">
                   <FileIcon className="w-5 h-5 text-gray-500" />
-                  <span className="truncate">{getReadableFileName(doc.file_name)}</span>
+                  <span className="truncate">{getDisplayFileName(doc.file_name)}</span>
                 </div>
                   <button
                     onClick={async () => {

--- a/frontend/src/pages/applicant/Step2_Upload.tsx
+++ b/frontend/src/pages/applicant/Step2_Upload.tsx
@@ -18,6 +18,7 @@ import { Button } from '../../components/ui/Button'
 import { Input } from '../../components/ui/Input'
 import ConfirmModal from '../../components/ui/ConfirmModal'
 import { downloadBlob } from '../../lib/download'
+import { getDisplayFileName } from '../../lib/file'
 
 const acceptMap: Record<string, string> = {
   pdf: 'application/pdf',
@@ -207,7 +208,7 @@ export default function Step2_Upload() {
                       }}
                       className="text-blue-600 underline text-sm"
                     >
-                      {a.file_name}
+                      {getDisplayFileName(a.file_name)}
                     </button>
                   </div>
                 ))}

--- a/frontend/src/pages/applicant/Step3_Review.tsx
+++ b/frontend/src/pages/applicant/Step3_Review.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ToastProvider'
 import { downloadBlob } from '../../lib/download'
+import { getDisplayFileName } from '../../lib/file'
 
 export default function Step3_Review() {
   const { callId } = useParams<{ callId: string }>()

--- a/frontend/src/pages/reviewer/ReviewApplicationPage.tsx
+++ b/frontend/src/pages/reviewer/ReviewApplicationPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../api'
 import { useToast } from '../../components/ToastProvider'
 import { downloadBlob } from '../../lib/download'
+import { getDisplayFileName } from '../../lib/file'
 
 export default function ReviewApplicationPage() {
   const { applicationId } = useParams<{ applicationId: string }>()
@@ -115,7 +116,7 @@ export default function ReviewApplicationPage() {
                 >
                   Download
                 </button>
-                <span className="ml-2">{att.file_name}</span>
+                <span className="ml-2">{getDisplayFileName(att.file_name)}</span>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- create `getDisplayFileName` helper under `lib`
- use helper everywhere filenames are shown

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f45d15d78832c88acde985bdbe99b