### PR TITLE
Add README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
+# ProjectCallPlatform
 
+ProjectCallPlatform is a web platform that helps organizations announce,
+receive and evaluate project proposals. The repository contains a FastAPI
+backend and a React + TypeScript frontend.
+
+## Requirements
+
+- Docker and Docker Compose (recommended for local setup)
+- Node.js (for running the frontend in development mode)
+- Python 3.11 (only required if running the backend without Docker)
+
+## Quick Start
+
+1. Clone the repository.
+2. Copy the example environment file and adjust the values as needed:
+   ```bash
+   cp backend/.env.example backend/.env
+   ```
+3. From the `backend` directory build and start the services:
+   ```bash
+   cd backend
+   docker-compose up --build
+   ```
+   The API will be available at `http://localhost:8000`.
+4. In a separate terminal install the frontend dependencies and start the dev
+   server:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+   The application will be available at `http://localhost:5173`.
+
+## Running Without Docker
+
+If you prefer running the backend locally, install the packages from
+`backend/requirements.txt` and make sure [`wkhtmltopdf`](https://wkhtmltopdf.org/)
+is installed on your system. After configuring `backend/.env`, start the server
+with:
+
+```bash
+uvicorn app.main:app --reload --port 8000
+```
+
+Database migrations are managed with Alembic. Run `alembic upgrade head` from the
+`backend` directory after setting `DATABASE_URL`.
+
+## Tests
+
+Backend tests are located in `backend/tests` and can be executed with `pytest`.
+Ensure that a test database is configured in the environment file when running
+these tests locally.
+
+## Notes
+
+- When running locally outside Docker, install `wkhtmltopdf` for PDF export
+  support.
+- Environment variables in `backend/.env` control database access, rate limiting
+  and JWT secrets. Do not commit sensitive values to version control.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for
+more information.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,20 @@
+# Database connection URL for SQLAlchemy
+database_url=postgresql://user:password@db:5432/app_db
+
+# Rate limiting
+requests_per_minute=60
+
+# Secret key used to sign JWT tokens
+jwt_secret=changeme
+
+# Allowed frontend origin for CORS (React app runs on this port)
+allowed_origins=http://localhost:5173
+
+# Automatically create database tables at startup (development only)
+create_tables=true
+
+# Base URL for the frontend application
+base_url=http://localhost:8000
+
+# Directory to store uploaded files
+upload_dir=uploads


### PR DESCRIPTION
## Summary
- document setup instructions and usage in new README
- add MIT license text
- provide `.env.example` for backend configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6873db23cab0832c95e6a9360883ad34